### PR TITLE
Enable getName function for Common APIs

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/entity/EntityRollingStock.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/EntityRollingStock.java
@@ -35,12 +35,12 @@ public class EntityRollingStock extends Entity implements IWorldData, ISpawnData
 		this.texture = texture;
 	}
 
-	/* TODO?
+	
 	@Override
 	public String getName() {
 		return this.getDefinition().name();
 	}
-	*/
+	
 
 	public String tryJoinWorld() {
 		if (DefinitionManager.getDefinition(defID) == null) {


### PR DESCRIPTION
- The Immersive Railroading Integration should use this function. Instead of call name() function directly.