### PR TITLE
Remove empty tag compound so items stack

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/multiblock/CastingMultiblock.java
+++ b/src/main/java/cam72cam/immersiverailroading/multiblock/CastingMultiblock.java
@@ -252,7 +252,11 @@ public class CastingMultiblock extends Multiblock {
 					if (mode == CraftingMachineMode.SINGLE) {
 						craftTe.setCraftMode(CraftingMachineMode.STOPPED);
 					}
-					outTe.getContainer().set(0, item.copy());
+					ItemStack outputItem = item.copy();
+					if (outputItem.getTagCompound().internal.hasNoTags()) {
+						outputItem.clearTagCompound();
+					}
+					outTe.getContainer().set(0, outputItem);
 				} else {
 					if (craftTe.getRenderTicks() % 10 == 0) {
 						if (fluidTe.getCraftProgress() > 0) {


### PR DESCRIPTION
The steel ingot and steel block cast out of the casting basin do not stack with the same items acquired elsewhere because an empty tag compound is applied to the item. This clears the tag compound if it is empty right before placing the item into the casting basin output title entity container.