### PR TITLE
Add cab forward support

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/entity/Locomotive.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/Locomotive.java
@@ -206,7 +206,7 @@ public abstract class Locomotive extends FreightTank {
 			}
 		}
 
-		simulateWheelSlip();
+		this.distanceTraveled += simulateWheelSlip();
 	}
 	
 	protected abstract int getAvailableHP();
@@ -219,14 +219,15 @@ public abstract class Locomotive extends FreightTank {
 		return tractiveEffortNewtons;
 	}
 	
-	private void simulateWheelSlip() {
+	protected double simulateWheelSlip() {
 		double tractiveEffortNewtons = getAppliedTractiveEffort(getCurrentSpeed());
 		double staticTractiveEffort = this.getDefinition().getStartingTractionNewtons(gauge) * slipCoefficient() * Config.ConfigBalance.tractionMultiplier;
 		staticTractiveEffort *= 1.5; // Fudge factor
 		double adhesionFactor = tractiveEffortNewtons / staticTractiveEffort;
 		if (adhesionFactor > 1) {
-			this.distanceTraveled += Math.copySign(Math.min((adhesionFactor-1)/10, 1), getThrottle());
+			return Math.copySign(Math.min((adhesionFactor-1)/10, 1), getThrottle());
 		}
+		return 0;
 	}
 	
 	public double getTractiveEffortNewtons(Speed speed) {	

--- a/src/main/java/cam72cam/immersiverailroading/entity/LocomotiveSteam.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/LocomotiveSteam.java
@@ -12,15 +12,12 @@ import cam72cam.immersiverailroading.library.ValveGearType;
 import cam72cam.immersiverailroading.model.RenderComponent;
 import cam72cam.immersiverailroading.registry.LocomotiveSteamDefinition;
 import cam72cam.immersiverailroading.registry.Quilling.Chime;
+import cam72cam.immersiverailroading.util.*;
 import cam72cam.mod.entity.sync.TagSync;
 import cam72cam.mod.gui.GuiRegistry;
 import cam72cam.mod.serialization.TagField;
 import cam72cam.mod.serialization.TagMapper;
 import cam72cam.mod.sound.ISound;
-import cam72cam.immersiverailroading.util.BurnUtil;
-import cam72cam.immersiverailroading.util.FluidQuantity;
-import cam72cam.immersiverailroading.util.LiquidUtil;
-import cam72cam.immersiverailroading.util.VecUtil;
 import cam72cam.mod.entity.Entity;
 import cam72cam.mod.fluid.Fluid;
 import cam72cam.mod.fluid.FluidStack;
@@ -150,7 +147,17 @@ public class LocomotiveSteam extends Locomotive {
 		phase = Math.abs(Math.cos(phase*Math.PI*spikes + Math.toRadians(offsetDegrees)));
 		return phase;
 	}
-	
+
+	@Override
+	public double getTractiveEffortNewtons(Speed speed) {
+		return (getDefinition().cab_forward ? -1 : 1) * super.getTractiveEffortNewtons(speed);
+	}
+
+	@Override
+	protected double simulateWheelSlip() {
+		return (getDefinition().cab_forward ? -1 : 1) * super.simulateWheelSlip();
+	}
+
 	private Map<String, Boolean> phaseOn = new HashMap<>();
 	private List<ISound> sndCache = new ArrayList<>();
 	private int sndCacheId = 0;
@@ -513,7 +520,7 @@ public class LocomotiveSteam extends Locomotive {
 		}
 
 		EntityCoupleableRollingStock stock = this;
-		CouplerType coupler = CouplerType.BACK;
+		CouplerType coupler = getDefinition().cab_forward ? CouplerType.FRONT : CouplerType.BACK;
 		while (coupler != null && stock.getCoupled(coupler) instanceof Tender) {
 			Tender tender = (Tender) stock.getCoupled(coupler);
 

--- a/src/main/java/cam72cam/immersiverailroading/registry/LocomotiveSteamDefinition.java
+++ b/src/main/java/cam72cam/immersiverailroading/registry/LocomotiveSteamDefinition.java
@@ -33,6 +33,7 @@ public class LocomotiveSteamDefinition extends LocomotiveDefinition {
     private int numSlots;
     private int width;
     public boolean tender_auto_feed;
+    public boolean cab_forward;
 
     public LocomotiveSteamDefinition(String defID, JsonObject data) throws Exception {
         super(LocomotiveSteam.class, defID, data);
@@ -54,6 +55,7 @@ public class LocomotiveSteamDefinition extends LocomotiveDefinition {
         this.numSlots = (int) Math.ceil(firebox.get("slots").getAsInt() * internal_inv_scale);
         this.width = (int) Math.ceil(firebox.get("width").getAsInt() * internal_inv_scale);
         this.tender_auto_feed = properties.has("tender_auto_feed") ? properties.get("tender_auto_feed").getAsBoolean() : true;
+        this.cab_forward = properties.has("cab_forward") && properties.get("cab_forward").getAsBoolean();
 
         JsonObject sounds = data.has("sounds") ? data.get("sounds").getAsJsonObject() : null;
 


### PR DESCRIPTION
This allows any existing locomotive's controls and tender connection to be reversed.  Eventually I want to make the animation system handle this alone, but for now this is a pretty small change and is easy to support.