### PR TITLE
Use items while on train

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/entity/Freight.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/Freight.java
@@ -106,9 +106,11 @@ public abstract class Freight extends EntityCoupleableRollingStock {
 			}
 		}
 		
-		if (guiType() != null) {
+		if (guiType() != null && player.getHeldItem(Player.Hand.PRIMARY).isEmpty() && player.getHeldItem(Player.Hand.SECONDARY).isEmpty()) {
 			guiType().open(player, this);
 			return ClickResult.ACCEPTED;
+		} else if (!player.getHeldItem(Player.Hand.PRIMARY).isEmpty()) {
+			player.getHeldItem(Player.Hand.PRIMARY).use(player.getWorld(), player, Player.Hand.PRIMARY);
 		}
 		return ClickResult.PASS;
 	}

--- a/src/main/java/cam72cam/immersiverailroading/entity/Freight.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/Freight.java
@@ -109,8 +109,6 @@ public abstract class Freight extends EntityCoupleableRollingStock {
 		if (guiType() != null && player.getHeldItem(Player.Hand.PRIMARY).isEmpty() && player.getHeldItem(Player.Hand.SECONDARY).isEmpty()) {
 			guiType().open(player, this);
 			return ClickResult.ACCEPTED;
-		} else if (!player.getHeldItem(Player.Hand.PRIMARY).isEmpty()) {
-			player.getHeldItem(Player.Hand.PRIMARY).use(player.getWorld(), player, Player.Hand.PRIMARY);
 		}
 		return ClickResult.PASS;
 	}


### PR DESCRIPTION
A hacky fix to allow instant use items, such as OC tablets, to be used while riding a train. This really shouldn't be how its done, but I suppose its step in the right direction that can be built upon before being merged.

Uses changes to UMC in https://github.com/Appw0/UniversalModCore/commit/ccc04c96f8d0b389e68ebf67feddb488afad79dd