### PR TITLE
add extra tooltip infos

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/items/ItemRollingStock.java
+++ b/src/main/java/cam72cam/immersiverailroading/items/ItemRollingStock.java
@@ -99,6 +99,9 @@ public class ItemRollingStock extends BaseItemRollingStock {
         if (texture != null && def != null && def.textureNames.get(texture) != null) {
 	        tooltip.add(GuiText.TEXTURE_TOOLTIP.toString(def.textureNames.get(texture)));
         }
+
+        tooltip.addAll(def.getExtraTooltipInfo());
+
         return tooltip;
     }
 	

--- a/src/main/java/cam72cam/immersiverailroading/registry/EntityRollingStockDefinition.java
+++ b/src/main/java/cam72cam/immersiverailroading/registry/EntityRollingStockDefinition.java
@@ -318,6 +318,8 @@ public abstract class EntityRollingStockDefinition {
         if (data.has("extra_tooltip_info")) {
             extraTooltipInfo = new ArrayList<>();
             data.getAsJsonArray("extra_tooltip_info").forEach(jsonElement -> extraTooltipInfo.add(jsonElement.getAsString()));
+        } else {
+            extraTooltipInfo = Collections.emptyList();
         }
     }
 
@@ -549,7 +551,6 @@ public abstract class EntityRollingStockDefinition {
         tips.add(GuiText.WEIGHT_TOOLTIP.toString(this.getWeight(gauge)));
         tips.add(GuiText.MODELER_TOOLTIP.toString(modelerName));
         tips.add(GuiText.PACK_TOOLTIP.toString(packName));
-        tips.addAll(extraTooltipInfo);
         return tips;
     }
 
@@ -623,5 +624,9 @@ public abstract class EntityRollingStockDefinition {
 
     public boolean isLinearBrakeControl() {
         return isLinearBrakeControl;
+    }
+
+    public List<String> getExtraTooltipInfo() {
+        return extraTooltipInfo;
     }
 }


### PR DESCRIPTION
Add the ability for pack makers to add extra tooltips to their models via `stock.json`s, using the new field `extra_tooltip_info`; this is an array of strings, where each element is one line of tooltip.