### PR TITLE
feat: add config to reset train speed [blocked]

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/Config.java
+++ b/src/main/java/cam72cam/immersiverailroading/Config.java
@@ -225,7 +225,10 @@ public class Config {
 
 		@Comment("Old Narrow track placement (single width instead of 3)")
         public static boolean oldNarrowWidth = false;
-	}
+
+		@Comment("Reset speed when loading stock")
+		public static boolean resetSpeedOnLoad = false;
+    }
 
 	public static boolean isFuelRequired(Gauge gauge) {
 		return !(!ConfigBalance.FuelRequired || (!ConfigBalance.ModelFuelRequired && gauge.isModel()));

--- a/src/main/java/cam72cam/immersiverailroading/entity/EntityMoveableRollingStock.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/EntityMoveableRollingStock.java
@@ -75,6 +75,12 @@ public abstract class EntityMoveableRollingStock extends EntityRidableRollingSto
     public void load(TagCompound data) {
         super.load(data);
 
+        if (ConfigDebug.resetSpeedOnLoad) {
+            for (TickPos position : this.positions) {
+                position.speed = Speed.ZERO;
+            }
+        }
+
         if (positions.isEmpty()) {
             this.tickPosID = 0;
             positions.add(getCurrentTickPosOrFake());


### PR DESCRIPTION
- adds a debug config option to reset speed when loading stock
- this is useful when automating trains (avoid incorrect switch while during cc computers are still booting)