### PR TITLE
Refactor sound scale and fix #1302

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/ConfigSound.java
+++ b/src/main/java/cam72cam/immersiverailroading/ConfigSound.java
@@ -18,6 +18,9 @@ public class ConfigSound {
 	@Comment("Sound Distance Multiplier")
 	public static double soundDistanceScale = 1;
 
+	@Comment("Scales sound emitted by rolling stock to the gauge they are on.  Requres restart.")
+	public static boolean scaleSoundToGauge = true;
+
 	//@RequiresMcRestart
 	@Comment("Re-configure the sound system to use more audo channels (fixes audio cutting out at high speed)")
 	public static boolean overrideSoundChannels = true;

--- a/src/main/java/cam72cam/immersiverailroading/ImmersiveRailroading.java
+++ b/src/main/java/cam72cam/immersiverailroading/ImmersiveRailroading.java
@@ -2,7 +2,6 @@ package cam72cam.immersiverailroading;
 
 import cam72cam.immersiverailroading.entity.*;
 import cam72cam.immersiverailroading.gui.overlay.GuiBuilder;
-import cam72cam.immersiverailroading.library.Gauge;
 import cam72cam.immersiverailroading.library.GuiTypes;
 import cam72cam.immersiverailroading.library.KeyTypes;
 import cam72cam.immersiverailroading.library.Particles;
@@ -38,7 +37,6 @@ import cam72cam.mod.render.*;
 import cam72cam.mod.render.opengl.RenderState;
 import cam72cam.mod.resource.Identifier;
 import cam72cam.mod.sound.Audio;
-import cam72cam.mod.sound.ISound;
 import cam72cam.mod.text.Command;
 
 import java.util.function.Function;
@@ -226,9 +224,5 @@ public class ImmersiveRailroading extends ModCore.Mod {
 
 	@Override
 	public void serverEvent(ModEvent event) {
-	}
-
-	public static ISound newSound(Identifier oggLocation, boolean repeats, float attenuationDistance, Gauge gauge) {
-		return Audio.newSound(oggLocation, Identifier::getResourceStream, repeats, (float) (attenuationDistance * gauge.scale() * ConfigSound.soundDistanceScale), (float)Math.sqrt(Math.sqrt(gauge.scale())));
 	}
 }

--- a/src/main/java/cam72cam/immersiverailroading/entity/EntityCoupleableRollingStock.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/EntityCoupleableRollingStock.java
@@ -278,7 +278,7 @@ public abstract class EntityCoupleableRollingStock extends EntityMoveableRolling
 				this.setCoupledUUID(coupler, stock.getUUID());
 				stock.setCoupledUUID(otherCoupler, this.getUUID());
 				if (stock.isCouplerEngaged(otherCoupler) && this.isCouplerEngaged(coupler)) {
-					new SoundPacket("immersiverailroading:sounds/default/coupling.ogg", this.getCouplerPosition(coupler), this.getVelocity(), 1, 1, 200, gauge)
+					new SoundPacket("immersiverailroading:sounds/default/coupling.ogg", this.getCouplerPosition(coupler), this.getVelocity(), 1, 1, 200, stock.soundScale())
 						.sendToObserving(this);
 				}
 			}

--- a/src/main/java/cam72cam/immersiverailroading/entity/EntityMoveableRollingStock.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/EntityMoveableRollingStock.java
@@ -313,18 +313,19 @@ public abstract class EntityMoveableRollingStock extends EntityRidableRollingSto
 
             if (ConfigSound.soundEnabled) {
                 if (this.wheel_sound == null) {
-                    wheel_sound = ImmersiveRailroading.newSound(this.getDefinition().wheel_sound, true, 40, gauge);
+                    wheel_sound = this.createSound(this.getDefinition().wheel_sound, true, 40);
                     this.sndRand = (float) Math.random() / 10;
                 }
                 if (this.clackFront == null) {
-                    clackFront = ImmersiveRailroading.newSound(this.getDefinition().clackFront, false, 30, gauge);
+                    clackFront = this.createSound(this.getDefinition().clackFront, false, 30);
                 }
                 if (this.clackRear == null) {
-                    clackRear = ImmersiveRailroading.newSound(this.getDefinition().clackRear, false, 30, gauge);
+                    clackRear = this.createSound(this.getDefinition().clackRear, false, 30);
                 }
                 float adjust = (float) Math.abs(this.getCurrentSpeed().metric()) / 300;
                 float pitch = adjust + 0.7f;
                 if (getDefinition().shouldScalePitch()) {
+                    // TODO this is probably wrong...
                     pitch = (float) (pitch/ gauge.scale());
                 }
                 float volume = 0.01f + adjust;

--- a/src/main/java/cam72cam/immersiverailroading/entity/EntityRollingStock.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/EntityRollingStock.java
@@ -1,6 +1,7 @@
 package cam72cam.immersiverailroading.entity;
 
 import cam72cam.immersiverailroading.Config.ConfigDamage;
+import cam72cam.immersiverailroading.ConfigSound;
 import cam72cam.immersiverailroading.IRItems;
 import cam72cam.immersiverailroading.ImmersiveRailroading;
 import cam72cam.immersiverailroading.library.*;
@@ -14,10 +15,14 @@ import cam72cam.mod.item.ClickResult;
 import cam72cam.mod.item.Fuzzy;
 import cam72cam.mod.item.ItemStack;
 import cam72cam.mod.math.Vec3d;
+import cam72cam.mod.resource.Identifier;
 import cam72cam.mod.serialization.*;
+import cam72cam.mod.sound.Audio;
+import cam72cam.mod.sound.ISound;
 import cam72cam.mod.text.PlayerMessage;
 import cam72cam.mod.util.SingleCache;
 import org.apache.commons.lang3.tuple.Pair;
+import trackapi.lib.Gauges;
 import util.Matrix4;
 
 import java.util.HashMap;
@@ -207,8 +212,17 @@ public class EntityRollingStock extends CustomEntity implements ITickable, IClic
 	public void triggerResimulate() {
 	}
 
-	public Gauge soundGauge() {
-		return this.getDefinition().shouldScalePitch() ? gauge : Gauge.from(Gauge.STANDARD);
+	public float soundScale() {
+		return this.getDefinition().shouldScalePitch() ? (float) Math.sqrt(Math.sqrt(gauge.scale())) : 1;
+	}
+
+	public ISound createSound(Identifier oggLocation, boolean repeats, double attenuationDistance) {
+		return Audio.newSound(
+				oggLocation, Identifier::getResourceStream,
+				repeats,
+				(float) (attenuationDistance * ConfigSound.soundDistanceScale * gauge.scale()),
+				soundScale()
+		);
 	}
 
 	public String getTexture() {

--- a/src/main/java/cam72cam/immersiverailroading/items/ItemConductorWhistle.java
+++ b/src/main/java/cam72cam/immersiverailroading/items/ItemConductorWhistle.java
@@ -3,7 +3,6 @@ package cam72cam.immersiverailroading.items;
 import cam72cam.immersiverailroading.Config;
 import cam72cam.immersiverailroading.ImmersiveRailroading;
 import cam72cam.immersiverailroading.entity.EntityCoupleableRollingStock;
-import cam72cam.immersiverailroading.library.Gauge;
 import cam72cam.immersiverailroading.library.Permissions;
 import cam72cam.immersiverailroading.net.SoundPacket;
 import cam72cam.mod.entity.Entity;
@@ -61,7 +60,7 @@ public class ItemConductorWhistle extends CustomItem {
 					player.getPosition(), Vec3d.ZERO,
 					0.7f, (float) (Math.random() / 4 + 0.75), 
 					(int) (Config.ConfigBalance.villagerConductorDistance * 1.2f), 
-					Gauge.from(Gauge.STANDARD)
+					1
 			);
 			packet.sendToAllAround(world, player.getPosition(), Config.ConfigBalance.villagerConductorDistance * 1.2f);
 

--- a/src/main/java/cam72cam/immersiverailroading/library/Gauge.java
+++ b/src/main/java/cam72cam/immersiverailroading/library/Gauge.java
@@ -29,7 +29,7 @@ public class Gauge {
 	public double scale() {
 		return gauge / Gauges.STANDARD;
 	}
-	
+
 	@Override
 	public String toString() {
 	    return TextUtil.translate("immersiverailroading:gauge." + name.toLowerCase(Locale.ROOT));

--- a/src/main/java/cam72cam/immersiverailroading/model/DieselLocomotiveModel.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/DieselLocomotiveModel.java
@@ -1,6 +1,5 @@
 package cam72cam.immersiverailroading.model;
 
-import cam72cam.immersiverailroading.ImmersiveRailroading;
 import cam72cam.immersiverailroading.entity.LocomotiveDiesel;
 import cam72cam.immersiverailroading.gui.overlay.Readouts;
 import cam72cam.immersiverailroading.library.ModelComponentType;
@@ -20,7 +19,7 @@ public class DieselLocomotiveModel extends LocomotiveModel<LocomotiveDiesel> {
 
     public DieselLocomotiveModel(LocomotiveDieselDefinition def) throws Exception {
         super(def);
-        idle = def.isCabCar() ? null : new PartSound(stock -> ImmersiveRailroading.newSound(def.idle, true, 80, stock.soundGauge()));
+        idle = def.isCabCar() ? null : new PartSound(stock -> stock.createSound(def.idle, true, 80));
     }
 
     @Override

--- a/src/main/java/cam72cam/immersiverailroading/model/SteamLocomotiveModel.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/SteamLocomotiveModel.java
@@ -1,7 +1,6 @@
 package cam72cam.immersiverailroading.model;
 
 import cam72cam.immersiverailroading.Config;
-import cam72cam.immersiverailroading.ImmersiveRailroading;
 import cam72cam.immersiverailroading.entity.LocomotiveSteam;
 import cam72cam.immersiverailroading.gui.overlay.Readouts;
 import cam72cam.immersiverailroading.library.ModelComponentType;
@@ -25,7 +24,7 @@ public class SteamLocomotiveModel extends LocomotiveModel<LocomotiveSteam> {
 
     public SteamLocomotiveModel(LocomotiveSteamDefinition def) throws Exception {
         super(def);
-        idleSounds = new PartSound(stock -> ImmersiveRailroading.newSound(def.idle, true, 40, stock.soundGauge()));
+        idleSounds = new PartSound(stock -> stock.createSound(def.idle, true, 40));
     }
 
     @Override

--- a/src/main/java/cam72cam/immersiverailroading/model/part/Bell.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/Bell.java
@@ -1,6 +1,5 @@
 package cam72cam.immersiverailroading.model.part;
 
-import cam72cam.immersiverailroading.ImmersiveRailroading;
 import cam72cam.immersiverailroading.library.ModelComponentType;
 import cam72cam.immersiverailroading.model.ComponentRenderer;
 import cam72cam.immersiverailroading.model.components.ComponentProvider;
@@ -16,7 +15,7 @@ public class Bell extends PartSound {
 
     public Bell(ModelComponent component, Identifier soundFile) {
         super(soundFile == null ? null :
-                stock -> ImmersiveRailroading.newSound(soundFile, true, 150, stock.soundGauge())
+                stock -> stock.createSound(soundFile, true, 150)
         );
         this.component = component;
     }

--- a/src/main/java/cam72cam/immersiverailroading/model/part/Control.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/Control.java
@@ -375,7 +375,7 @@ public class Control<T extends EntityMoveableRollingStock>  {
         if (sound == null) {
             return;
         }
-        ISound snd = ImmersiveRailroading.newSound(sound, repeats, 10, stock.gauge);
+        ISound snd = stock.createSound(sound, repeats, 10);
         snd.setVelocity(stock.getVelocity());
         snd.setVolume(1);
         snd.setPitch(1f);

--- a/src/main/java/cam72cam/immersiverailroading/model/part/Horn.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/Horn.java
@@ -15,7 +15,7 @@ public class Horn extends PartSound {
     }
 
     public Horn(ModelComponent component, Identifier soundFile, boolean repeats) {
-        super(stock -> ImmersiveRailroading.newSound(soundFile, repeats, 100, stock.soundGauge()));
+        super(stock -> stock.createSound(soundFile, repeats, 100));
         this.component = component;
     }
 

--- a/src/main/java/cam72cam/immersiverailroading/model/part/PressureValve.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/PressureValve.java
@@ -2,7 +2,6 @@ package cam72cam.immersiverailroading.model.part;
 
 import cam72cam.immersiverailroading.ConfigGraphics;
 import cam72cam.immersiverailroading.ConfigSound;
-import cam72cam.immersiverailroading.ImmersiveRailroading;
 import cam72cam.immersiverailroading.entity.EntityMoveableRollingStock;
 import cam72cam.immersiverailroading.library.ModelComponentType;
 import cam72cam.immersiverailroading.library.Particles;
@@ -43,7 +42,7 @@ public class PressureValve {
         if (ConfigSound.soundEnabled && ConfigSound.soundPressureValve) {
             ISound sound = sounds.get(stock.getUUID());
             if (sound == null) {
-                sound = ImmersiveRailroading.newSound(sndFile, true, 40, stock.soundGauge());
+                sound = stock.createSound(sndFile, true, 40);
                 sound.setVolume(0.3f);
                 sounds.put(stock.getUUID(), sound);
             }

--- a/src/main/java/cam72cam/immersiverailroading/model/part/StephensonValveGear.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/StephensonValveGear.java
@@ -2,7 +2,6 @@ package cam72cam.immersiverailroading.model.part;
 
 import cam72cam.immersiverailroading.ConfigGraphics;
 import cam72cam.immersiverailroading.ConfigSound;
-import cam72cam.immersiverailroading.ImmersiveRailroading;
 import cam72cam.immersiverailroading.entity.EntityMoveableRollingStock;
 import cam72cam.immersiverailroading.entity.LocomotiveSteam;
 import cam72cam.immersiverailroading.library.ModelComponentType;
@@ -81,7 +80,7 @@ public class StephensonValveGear extends ConnectingRodValveGear {
             chuffId = 0;
             chuffs = new ArrayList<>();
             for (int i = 0; i < 6; i++) {
-                chuffs.add(ImmersiveRailroading.newSound(stock.getDefinition().chuff, false, 80, stock.soundGauge()));
+                chuffs.add(stock.createSound(stock.getDefinition().chuff, false, 80));
             }
             this.stock = stock;
             this.pitchOffset = (float) (Math.random() / 50);

--- a/src/main/java/cam72cam/immersiverailroading/model/part/Whistle.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/Whistle.java
@@ -1,9 +1,7 @@
 package cam72cam.immersiverailroading.model.part;
 
 import cam72cam.immersiverailroading.ConfigSound;
-import cam72cam.immersiverailroading.ImmersiveRailroading;
 import cam72cam.immersiverailroading.entity.EntityMoveableRollingStock;
-import cam72cam.immersiverailroading.library.Gauge;
 import cam72cam.immersiverailroading.library.ModelComponentType;
 import cam72cam.immersiverailroading.library.Particles;
 import cam72cam.immersiverailroading.model.ComponentRenderer;
@@ -44,16 +42,16 @@ public class Whistle {
         private float pullString = 0;
         private float soundDampener = 0;
 
-        private SoundEffects(Gauge gauge) {
+        private SoundEffects(EntityMoveableRollingStock stock) {
             if (quilling != null) {
                 whistle = null;
                 chimes = new ArrayList<>();
                 for (Quilling.Chime chime : quilling.chimes) {
-                    chimes.add(ImmersiveRailroading.newSound(chime.sample, true, 150, gauge));
+                    chimes.add(stock.createSound(chime.sample, true, 150));
                 }
             } else {
                 chimes = null;
-                whistle = ImmersiveRailroading.newSound(fallback, false, 150, gauge);
+                whistle = stock.createSound(fallback, false, 150);
                 whistle.setPitch(1);
             }
         }
@@ -179,7 +177,7 @@ public class Whistle {
             SoundEffects sound = sounds.get(stock.getUUID());
 
             if (sound == null) {
-                sound = new SoundEffects(stock.soundGauge());
+                sound = new SoundEffects(stock);
                 sounds.put(stock.getUUID(), sound);
             }
 

--- a/src/main/java/cam72cam/immersiverailroading/net/SoundPacket.java
+++ b/src/main/java/cam72cam/immersiverailroading/net/SoundPacket.java
@@ -1,8 +1,8 @@
 package cam72cam.immersiverailroading.net;
 
-import cam72cam.immersiverailroading.ImmersiveRailroading;
-import cam72cam.immersiverailroading.library.Gauge;
+import cam72cam.immersiverailroading.ConfigSound;
 import cam72cam.mod.serialization.TagField;
+import cam72cam.mod.sound.Audio;
 import cam72cam.mod.sound.ISound;
 import cam72cam.mod.math.Vec3d;
 import cam72cam.mod.net.Packet;
@@ -22,23 +22,22 @@ public class SoundPacket extends Packet {
 	@TagField
 	private int distance;
 	@TagField
-	private double gauge;
+	private float scale;
 
 	public SoundPacket() { }
-	public SoundPacket(String soundfile, Vec3d pos, Vec3d motion, float volume, float pitch, int distance, Gauge gauge) {
+	public SoundPacket(String soundfile, Vec3d pos, Vec3d motion, float volume, float pitch, int distance, float scale) {
 		this.file = soundfile;
 		this.pos = pos;
 		this.motion = motion;
 		this.volume = volume;
 		this.pitch = pitch;
 		this.distance = distance;
-		this.gauge = gauge.value();
+		this.scale = scale;
 	}
 
 	@Override
 	public void handle() {
-		Gauge gauge = Gauge.from(this.gauge);
-		ISound snd = ImmersiveRailroading.newSound(new Identifier(file), false, distance, gauge);
+		ISound snd = Audio.newSound(new Identifier(file), Identifier::getResourceStream, false, (float) (distance * ConfigSound.soundDistanceScale), scale);
 		snd.setVelocity(motion);
 		snd.setVolume(volume);
 		snd.setPitch(pitch);

--- a/src/main/java/cam72cam/immersiverailroading/registry/EntityRollingStockDefinition.java
+++ b/src/main/java/cam72cam/immersiverailroading/registry/EntityRollingStockDefinition.java
@@ -1,5 +1,6 @@
 package cam72cam.immersiverailroading.registry;
 
+import cam72cam.immersiverailroading.ConfigSound;
 import cam72cam.immersiverailroading.ImmersiveRailroading;
 import cam72cam.immersiverailroading.entity.EntityBuildableRollingStock;
 import cam72cam.immersiverailroading.entity.EntityCoupleableRollingStock.CouplerType;
@@ -202,7 +203,7 @@ public abstract class EntityRollingStockDefinition {
     }
 
     public boolean shouldScalePitch() {
-        return scalePitch;
+        return ConfigSound.scaleSoundToGauge && scalePitch;
     }
 
     public void parseJson(JsonObject data) throws Exception {


### PR DESCRIPTION
The method of creating a new audio effect had a lot of unfortunate copy paste.  It also did not separate attenuation distance by gauge (always)  vs audio pitch scaled by gauge (optional).

Once the basic changes were done, I added a config setting to turn off the gauge pitch scaling as some members had requested it.