### PR TITLE
Dynamic cargo render

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/library/ModelComponentType.java
+++ b/src/main/java/cam72cam/immersiverailroading/library/ModelComponentType.java
@@ -77,6 +77,7 @@ public enum ModelComponentType {
 	// Cargo
 	CARGO_FILL_X("CARGO_FILL_#ID#"),
 	CARGO_FILL_POS_X("CARGO_FILL_#POS#_#ID#"),
+	CARGO_ITEMS_X("CARGO_ITEMS_#ID#"),
 
 	// Lights
 	HEADLIGHT_X("HEADLIGHT_#ID#"),

--- a/src/main/java/cam72cam/immersiverailroading/model/FreightModel.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/FreightModel.java
@@ -1,15 +1,18 @@
 package cam72cam.immersiverailroading.model;
 
 import cam72cam.immersiverailroading.model.components.ComponentProvider;
-import cam72cam.immersiverailroading.model.part.Cargo;
+import cam72cam.immersiverailroading.model.part.CargoFill;
 import cam72cam.immersiverailroading.entity.Freight;
+import cam72cam.immersiverailroading.model.part.CargoItems;
 import cam72cam.immersiverailroading.registry.EntityRollingStockDefinition;
 import cam72cam.immersiverailroading.registry.FreightDefinition;
+import cam72cam.mod.render.opengl.RenderState;
 
 public class FreightModel<T extends Freight> extends StockModel<T> {
     private final FreightDefinition def;
 
-    private Cargo cargo;
+    private CargoFill cargoFill;
+    private CargoItems cargoItems;
 
     public FreightModel(FreightDefinition def) throws Exception {
         super(def);
@@ -18,14 +21,24 @@ public class FreightModel<T extends Freight> extends StockModel<T> {
 
     protected void parseComponents(ComponentProvider provider, EntityRollingStockDefinition def) {
         super.parseComponents(provider, def);
-        this.cargo = Cargo.get(provider, null);
+        this.cargoFill = CargoFill.get(provider, null);
+        this.cargoItems = CargoItems.get(provider);
     }
 
     @Override
     protected void render(T stock, ComponentRenderer draw, double distanceTraveled) {
         super.render(stock, draw, distanceTraveled);
-        if (cargo != null) {
-            cargo.render(stock.getPercentCargoFull(), def.shouldShowCurrentLoadOnly(), draw);
+        if (cargoFill != null) {
+            cargoFill.render(stock.getPercentCargoFull(), def.shouldShowCurrentLoadOnly(), draw);
+        }
+    }
+
+    @Override
+    protected void postRender(T stock, RenderState state) {
+        super.postRender(stock, state);
+
+        if (cargoItems != null) {
+            cargoItems.postRender(stock, state);
         }
     }
 }

--- a/src/main/java/cam72cam/immersiverailroading/model/LocomotiveModel.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/LocomotiveModel.java
@@ -24,8 +24,8 @@ public class LocomotiveModel<T extends Locomotive> extends FreightTankModel<T> {
     private ModelComponent frameRear;
     protected DrivingAssembly drivingWheelsFront;
     protected DrivingAssembly drivingWheelsRear;
-    private Cargo cargoFront;
-    private Cargo cargoRear;
+    private CargoFill cargoFillFront;
+    private CargoFill cargoFillRear;
     private ModelComponent shellFront;
     private ModelComponent shellRear;
 
@@ -98,12 +98,12 @@ public class LocomotiveModel<T extends Locomotive> extends FreightTankModel<T> {
         ValveGearType type = def.getValveGear();
 
         frameFront = provider.parse(ModelComponentType.FRONT_FRAME);
-        cargoFront = Cargo.get(provider, ModelPosition.FRONT);
+        cargoFillFront = CargoFill.get(provider, ModelPosition.FRONT);
         shellFront = provider.parse(ModelComponentType.FRONT_SHELL);
         drivingWheelsFront = DrivingAssembly.get(type,provider, ModelPosition.FRONT, 0);
 
         frameRear = provider.parse(ModelComponentType.REAR_FRAME);
-        cargoRear = Cargo.get(provider, ModelPosition.REAR);
+        cargoFillRear = CargoFill.get(provider, ModelPosition.REAR);
         shellRear = provider.parse(ModelComponentType.REAR_SHELL);
         drivingWheelsRear = DrivingAssembly.get(type, provider, ModelPosition.REAR, 45);
 
@@ -171,8 +171,8 @@ public class LocomotiveModel<T extends Locomotive> extends FreightTankModel<T> {
                     drivingWheelsFront.render(distanceTraveled, stock.getReverser(), noSway);
                 }
                 matrix.render(shellFront);
-                if (cargoFront != null) {
-                    cargoFront.render(stock.getPercentCargoFull(), stock.getDefinition().shouldShowCurrentLoadOnly(), matrix);
+                if (cargoFillFront != null) {
+                    cargoFillFront.render(stock.getPercentCargoFull(), stock.getDefinition().shouldShowCurrentLoadOnly(), matrix);
                 }
             }
         }
@@ -187,8 +187,8 @@ public class LocomotiveModel<T extends Locomotive> extends FreightTankModel<T> {
                     drivingWheelsRear.render(distanceTraveled, stock.getReverser(), noSway);
                 }
                 matrix.render(shellRear);
-                if (cargoRear != null) {
-                    cargoRear.render(stock.getPercentCargoFull(), stock.getDefinition().shouldShowCurrentLoadOnly(), matrix);
+                if (cargoFillRear != null) {
+                    cargoFillRear.render(stock.getPercentCargoFull(), stock.getDefinition().shouldShowCurrentLoadOnly(), matrix);
                 }
             }
         }

--- a/src/main/java/cam72cam/immersiverailroading/model/part/CargoFill.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/CargoFill.java
@@ -8,15 +8,15 @@ import cam72cam.immersiverailroading.model.components.ModelComponent;
 
 import java.util.List;
 
-public class Cargo {
+public class CargoFill {
     private final List<ModelComponent> cargoLoads;
 
-    public static Cargo get(ComponentProvider provider, ModelPosition pos) {
+    public static CargoFill get(ComponentProvider provider, ModelPosition pos) {
         List<ModelComponent> cargoLoads = pos == null ? provider.parseAll(ModelComponentType.CARGO_FILL_X) : provider.parseAll(ModelComponentType.CARGO_FILL_POS_X, pos);
-        return cargoLoads.isEmpty() ? null : new Cargo(cargoLoads);
+        return cargoLoads.isEmpty() ? null : new CargoFill(cargoLoads);
     }
 
-    public Cargo(List<ModelComponent> cargoLoads) {
+    public CargoFill(List<ModelComponent> cargoLoads) {
         this.cargoLoads = cargoLoads;
     }
 

--- a/src/main/java/cam72cam/immersiverailroading/model/part/CargoItems.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/CargoItems.java
@@ -4,6 +4,7 @@ import cam72cam.immersiverailroading.entity.Freight;
 import cam72cam.immersiverailroading.library.ModelComponentType;
 import cam72cam.immersiverailroading.model.components.ComponentProvider;
 import cam72cam.immersiverailroading.model.components.ModelComponent;
+import cam72cam.mod.item.ItemStack;
 import cam72cam.mod.render.StandardModel;
 import cam72cam.mod.render.opengl.RenderState;
 import util.Matrix4;
@@ -38,39 +39,48 @@ public class CargoItems {
         if (model == null) {
             model = new StandardModel();
 
-            ModelComponent area = areas.get(0);
+            double totalVolume = areas.stream().mapToDouble(a -> a.length() * a.width() * a.height()).sum();
+            int slotOffset = 0;
+            for (ModelComponent area : areas) {
+                double itemsX = area.length();
+                double itemsY = area.height();
+                double itemsZ = area.width();
 
-            double cargoVolume = stock.cargoItems.getSlotCount();
+                double modelVolume = itemsX * itemsY * itemsZ;
+                int cargoVolume = (int) Math.ceil(stock.cargoItems.getSlotCount() * modelVolume/totalVolume);
 
-            double itemsX = area.length();
-            double itemsY = area.height();
-            double itemsZ = area.width();
+                double volumeRatio = Math.pow(cargoVolume / modelVolume, 0.3333);
+                itemsY = Math.ceil(itemsY * volumeRatio);
 
-            double modelVolume = itemsX * itemsY * itemsZ;
-            double volumeRatio = Math.pow(cargoVolume / modelVolume, 0.3333);
-            itemsY = Math.ceil(itemsY * volumeRatio);
+                modelVolume = itemsX * itemsY * itemsZ;
+                volumeRatio = Math.pow(cargoVolume / modelVolume, 0.3333);
+                itemsZ = Math.ceil(itemsZ * volumeRatio);
 
-            modelVolume = itemsX * itemsY * itemsZ;
-            volumeRatio = Math.pow(cargoVolume / modelVolume, 0.3333);
-            itemsZ = Math.ceil(itemsZ * volumeRatio);
+                modelVolume = itemsX * itemsY * itemsZ;
+                volumeRatio = cargoVolume / modelVolume;
+                itemsX = Math.ceil(itemsX * volumeRatio);
 
-            modelVolume = itemsX * itemsY * itemsZ;
-            volumeRatio = Math.pow(cargoVolume / modelVolume, 0.3333);
-            itemsX = Math.ceil(itemsX * volumeRatio);
+                int renderSlot = 0;
+                for (int i = slotOffset; i < Math.min(slotOffset+ cargoVolume, stock.cargoItems.getSlotCount()); i++) {
+                    ItemStack stack = stock.cargoItems.get(i);
+                    if (stack.isEmpty()) {
+                        continue;
+                    }
+                    int x = renderSlot % (int) itemsX;
+                    int z = (renderSlot / (int) itemsX) % (int) itemsZ;
+                    int y = (renderSlot / (int) itemsX / (int) itemsZ) % (int) itemsY;
 
-            for (int i = 0; i < stock.cargoItems.getSlotCount(); i++) {
-                int x = i % (int) itemsX;
-                int z = (i / (int) itemsX) % (int) itemsZ;
-                int y = (i / (int) itemsX / (int) itemsZ) % (int) itemsY;
-
-                model.addItem(
-                        stock.cargoItems.get(i),
-                        new Matrix4().
-                                translate(area.min.x, area.min.y, area.min.z)
-                                .scale(area.length() / itemsX, area.height() / itemsY, area.width() / itemsZ)
-                                .translate(0.5, 0.5, 0.5)
-                                .translate(x, y, z)
-                );
+                    model.addItem(
+                            stack,
+                            new Matrix4().
+                                    translate(area.min.x, area.min.y, area.min.z)
+                                    .scale(area.length() / itemsX, area.height() / itemsY, area.width() / itemsZ)
+                                    .translate(0.5, 0.5, 0.5)
+                                    .translate(x, y, z)
+                    );
+                    renderSlot++;
+                }
+                slotOffset += cargoVolume;
             }
             cache.put(stock.getUUID(), model);
         }

--- a/src/main/java/cam72cam/immersiverailroading/model/part/CargoItems.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/CargoItems.java
@@ -1,0 +1,79 @@
+package cam72cam.immersiverailroading.model.part;
+
+import cam72cam.immersiverailroading.entity.Freight;
+import cam72cam.immersiverailroading.library.ModelComponentType;
+import cam72cam.immersiverailroading.model.components.ComponentProvider;
+import cam72cam.immersiverailroading.model.components.ModelComponent;
+import cam72cam.mod.render.StandardModel;
+import cam72cam.mod.render.opengl.RenderState;
+import util.Matrix4;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public class CargoItems {
+    private final Map<UUID, StandardModel> cache = new HashMap<>();
+    private long lastUpdate = 0;
+
+    private final List<ModelComponent> areas;
+
+    public static CargoItems get(ComponentProvider provider) {
+        List<ModelComponent> found = provider.parseAll(ModelComponentType.CARGO_ITEMS_X);
+        return found.isEmpty() ? null : new CargoItems(found);
+    }
+
+    public CargoItems(List<ModelComponent> areas) {
+        this.areas = areas;
+    }
+
+    public <T extends Freight> void postRender(T stock, RenderState state) {
+        if (stock.getWorld().getTicks() > lastUpdate + 40) {
+            cache.clear();
+            lastUpdate = stock.getWorld().getTicks();
+        }
+
+        StandardModel model = cache.get(stock.getUUID());
+        if (model == null) {
+            model = new StandardModel();
+
+            ModelComponent area = areas.get(0);
+
+            double cargoVolume = stock.cargoItems.getSlotCount();
+
+            double itemsX = area.length();
+            double itemsY = area.height();
+            double itemsZ = area.width();
+
+            double modelVolume = itemsX * itemsY * itemsZ;
+            double volumeRatio = Math.pow(cargoVolume / modelVolume, 0.3333);
+            itemsY = Math.ceil(itemsY * volumeRatio);
+
+            modelVolume = itemsX * itemsY * itemsZ;
+            volumeRatio = Math.pow(cargoVolume / modelVolume, 0.3333);
+            itemsZ = Math.ceil(itemsZ * volumeRatio);
+
+            modelVolume = itemsX * itemsY * itemsZ;
+            volumeRatio = Math.pow(cargoVolume / modelVolume, 0.3333);
+            itemsX = Math.ceil(itemsX * volumeRatio);
+
+            for (int i = 0; i < stock.cargoItems.getSlotCount(); i++) {
+                int x = i % (int) itemsX;
+                int z = (i / (int) itemsX) % (int) itemsZ;
+                int y = (i / (int) itemsX / (int) itemsZ) % (int) itemsY;
+
+                model.addItem(
+                        stock.cargoItems.get(i),
+                        new Matrix4().
+                                translate(area.min.x, area.min.y, area.min.z)
+                                .scale(area.length() / itemsX, area.height() / itemsY, area.width() / itemsZ)
+                                .translate(0.5, 0.5, 0.5)
+                                .translate(x, y, z)
+                );
+            }
+            cache.put(stock.getUUID(), model);
+        }
+        model.render(state);
+    }
+}

--- a/src/main/java/cam72cam/immersiverailroading/model/part/CargoItems.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/CargoItems.java
@@ -18,15 +18,15 @@ public class CargoItems {
     private final Map<UUID, StandardModel> cache = new HashMap<>();
     private long lastUpdate = 0;
 
-    private final List<ModelComponent> areas;
+    private final List<ModelComponent> components;
 
     public static CargoItems get(ComponentProvider provider) {
         List<ModelComponent> found = provider.parseAll(ModelComponentType.CARGO_ITEMS_X);
         return found.isEmpty() ? null : new CargoItems(found);
     }
 
-    public CargoItems(List<ModelComponent> areas) {
-        this.areas = areas;
+    public CargoItems(List<ModelComponent> components) {
+        this.components = components;
     }
 
     public <T extends Freight> void postRender(T stock, RenderState state) {
@@ -39,12 +39,12 @@ public class CargoItems {
         if (model == null) {
             model = new StandardModel();
 
-            double totalVolume = areas.stream().mapToDouble(a -> a.length() * a.width() * a.height()).sum();
+            double totalVolume = components.stream().mapToDouble(a -> a.length() * a.width() * a.height()).sum();
             int slotOffset = 0;
-            for (ModelComponent area : areas) {
-                double itemsX = area.length();
-                double itemsY = area.height();
-                double itemsZ = area.width();
+            for (ModelComponent comp : components) {
+                double itemsX = comp.length();
+                double itemsY = comp.height();
+                double itemsZ = comp.width();
 
                 double modelVolume = itemsX * itemsY * itemsZ;
                 int cargoVolume = (int) Math.ceil(stock.cargoItems.getSlotCount() * modelVolume/totalVolume);
@@ -73,8 +73,8 @@ public class CargoItems {
                     model.addItem(
                             stack,
                             new Matrix4().
-                                    translate(area.min.x, area.min.y, area.min.z)
-                                    .scale(area.length() / itemsX, area.height() / itemsY, area.width() / itemsZ)
+                                    translate(comp.min.x, comp.min.y, comp.min.z)
+                                    .scale(comp.length() / itemsX, comp.height() / itemsY, comp.width() / itemsZ)
                                     .translate(0.5, 0.5, 0.5)
                                     .translate(x, y, z)
                     );

--- a/src/main/java/cam72cam/immersiverailroading/model/part/CargoItems.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/CargoItems.java
@@ -1,5 +1,6 @@
 package cam72cam.immersiverailroading.model.part;
 
+import cam72cam.immersiverailroading.IRItems;
 import cam72cam.immersiverailroading.entity.Freight;
 import cam72cam.immersiverailroading.library.ModelComponentType;
 import cam72cam.immersiverailroading.model.components.ComponentProvider;
@@ -70,13 +71,25 @@ public class CargoItems {
                     int z = (renderSlot / (int) itemsX) % (int) itemsZ;
                     int y = (renderSlot / (int) itemsX / (int) itemsZ) % (int) itemsY;
 
+                    double scaleX = comp.length() / itemsX;
+                    double scaleY = comp.height() / itemsY;
+                    double scaleZ = comp.width() / itemsZ;
+                    if (!comp.key.contains("STRETCHED")) {
+                        scaleX = scaleY = scaleZ = Math.min(comp.length() / itemsX, Math.min(comp.height() / itemsY, comp.width() / itemsZ));
+                    }
+                    double rot = 0;
+                    if (stack.is(IRItems.ITEM_ROLLING_STOCK) || stack.is(IRItems.ITEM_ROLLING_STOCK_COMPONENT)) {
+                        rot = 90;
+                    }
+
                     model.addItem(
                             stack,
                             new Matrix4().
                                     translate(comp.min.x, comp.min.y, comp.min.z)
-                                    .scale(comp.length() / itemsX, comp.height() / itemsY, comp.width() / itemsZ)
+                                    .scale(scaleX, scaleY, scaleZ)
                                     .translate(0.5, 0.5, 0.5)
                                     .translate(x, y, z)
+                                    .rotate(Math.toRadians(rot), 0, 1, 0)
                     );
                     renderSlot++;
                 }


### PR DESCRIPTION
Fixes #8


Re-renders every 2 seconds (instead of every frame) to reduce lag.

![2022-12-15_15 18 45](https://user-images.githubusercontent.com/892136/207899101-de75dd7e-451a-49dc-ae25-d8438fc0ab59.png)
![2022-12-15_15 19 06](https://user-images.githubusercontent.com/892136/207899103-d7c16767-cc18-4fd2-819d-d8cf7980e914.png)

Implemented in model as CARGO_ITEMS_#ID# as a box that will not be rendered.  Adding STRETCHED to the group name will force the items to fill the area exactly (instead of snapping to the nearest cubic size)