### PR TITLE
Diesel Startup Sound

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,5 +21,6 @@ Artemiy Danilin (Trollebas)
 Cyberslas (littlej54192)
 Tovlyn
 Florian Kostenzer (123FLO321)
+Ben K. (Xyvoracle)
 
 See sounds/CREDITS for links to the audio sources and their licensing info

--- a/src/main/java/cam72cam/immersiverailroading/model/DieselLocomotiveModel.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/DieselLocomotiveModel.java
@@ -20,7 +20,9 @@ public class DieselLocomotiveModel extends LocomotiveModel<LocomotiveDiesel> {
 
     public DieselLocomotiveModel(LocomotiveDieselDefinition def) throws Exception {
         super(def);
-        idle = def.isCabCar() ? null : new PartSound(stock -> ImmersiveRailroading.newSound(def.idle, true, 80, stock.soundGauge()));
+        idle = def.isCabCar() ? null : new PartSound(
+                stock -> ImmersiveRailroading.newSound(def.start, true, 80, stock.soundGauge()), //Start sound
+                stock -> ImmersiveRailroading.newSound(def.idle, true, 80, stock.soundGauge())); //Loop sound
     }
 
     @Override

--- a/src/main/java/cam72cam/immersiverailroading/model/DieselLocomotiveModel.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/DieselLocomotiveModel.java
@@ -21,7 +21,7 @@ public class DieselLocomotiveModel extends LocomotiveModel<LocomotiveDiesel> {
     public DieselLocomotiveModel(LocomotiveDieselDefinition def) throws Exception {
         super(def);
         idle = def.isCabCar() ? null : new PartSound(
-                stock -> ImmersiveRailroading.newSound(def.start, true, 80, stock.soundGauge()), //Start sound
+                stock -> ImmersiveRailroading.newSound(def.start, false, 80, stock.soundGauge()), //Start sound
                 stock -> ImmersiveRailroading.newSound(def.idle, true, 80, stock.soundGauge())); //Loop sound
     }
 

--- a/src/main/java/cam72cam/immersiverailroading/model/DieselLocomotiveModel.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/DieselLocomotiveModel.java
@@ -20,9 +20,13 @@ public class DieselLocomotiveModel extends LocomotiveModel<LocomotiveDiesel> {
 
     public DieselLocomotiveModel(LocomotiveDieselDefinition def) throws Exception {
         super(def);
-        idle = def.isCabCar() ? null : new PartSound(
-                stock -> ImmersiveRailroading.newSound(def.start, false, 80, stock.soundGauge()), //Start sound
-                stock -> ImmersiveRailroading.newSound(def.idle, true, 80, stock.soundGauge())); //Loop sound
+        if(def.start != null) {
+            idle = def.isCabCar() ? null : new PartSound(
+                    stock -> ImmersiveRailroading.newSound(def.start, false, 80, stock.soundGauge()), //Start sound
+                    stock -> ImmersiveRailroading.newSound(def.idle, true, 80, stock.soundGauge())); //Loop sound
+        } else {
+            idle = def.isCabCar() ? null : new PartSound(stock -> ImmersiveRailroading.newSound(def.idle, true, 80, stock.soundGauge()));
+        }
     }
 
     @Override

--- a/src/main/java/cam72cam/immersiverailroading/model/part/PartSound.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/PartSound.java
@@ -71,13 +71,12 @@ public class PartSound {
                     startSound.setVolume(volume);
                     startSound.setPitch(pitch);
 
-                    if(!startSound.isPlaying() && !startHasPlayed) { //If nothing has started yet
-                        startSound.play(stock.getPosition());
-                        startIsPlaying = true;
-                    } else if (!startSound.isPlaying() && startIsPlaying) { //Start sound is done playing one take
+                    if (!startSound.isPlaying() && startIsPlaying) { //Start sound is done playing one take
                         startHasPlayed = true;
                         startIsPlaying = false;
-                        startSound.stop();
+                    } else if(!startSound.isPlaying() && !startHasPlayed) { //If nothing has started yet
+                        startSound.play(stock.getPosition());
+                        startIsPlaying = true;
                     } else {
                         startSound.update();
                     }

--- a/src/main/java/cam72cam/immersiverailroading/model/part/PartSound.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/PartSound.java
@@ -9,16 +9,34 @@ import java.util.UUID;
 import java.util.function.Function;
 
 public class PartSound {
-    private final Function<EntityMoveableRollingStock, ISound> create;
+    private final Function<EntityMoveableRollingStock, ISound> loopCreate;
+    private final Function<EntityMoveableRollingStock, ISound> startCreate;
+    private final Function<EntityMoveableRollingStock, ISound> endCreate;
 
-    public PartSound(Function<EntityMoveableRollingStock, ISound> create) {
-        this.create = create;
+    public PartSound(Function<EntityMoveableRollingStock, ISound> loopCreate)
+    { this.startCreate = null; this.loopCreate = loopCreate; this.endCreate = null;}
+    public PartSound(Function<EntityMoveableRollingStock, ISound> startCreate, Function<EntityMoveableRollingStock, ISound> loopCreate)
+    { this.startCreate = startCreate; this.loopCreate = loopCreate; this.endCreate = null;}
+    public PartSound(Function<EntityMoveableRollingStock, ISound> startCreate, Function<EntityMoveableRollingStock, ISound> loopCreate, Function<EntityMoveableRollingStock, ISound> endCreate)
+    { this.startCreate = startCreate; this.loopCreate = loopCreate; this.endCreate = endCreate;}
+
+    private boolean startIsPlaying;
+    private boolean startHasPlayed;
+    private boolean endIsPlaying; //Unused
+    private boolean endHasPlayed;
+
+    class Sounds {
+        ISound start;
+        ISound loop;
+        ISound end;
     }
 
-    private final ExpireableMap<UUID, ISound> sounds = new ExpireableMap<UUID, ISound>() {
+    private final ExpireableMap<UUID, Sounds> sounds = new ExpireableMap<UUID, Sounds>() {
         @Override
-        public void onRemove(UUID key, ISound value) {
-            value.terminate();
+        public void onRemove(UUID key, Sounds value) {
+            value.start.terminate();
+            value.loop.terminate();
+            value.end.terminate();
         }
     };
 
@@ -31,36 +49,74 @@ public class PartSound {
     }
 
     public void effects(EntityMoveableRollingStock stock, float volume, float pitch) {
-        if (ConfigSound.soundEnabled && create != null) {
-            ISound sound = sounds.get(stock.getUUID());
-            if (sound == null) {
-                sound = create.apply(stock);
-                sounds.put(stock.getUUID(), sound);
+        if (ConfigSound.soundEnabled && loopCreate != null) {
+
+            Sounds soundTrio = sounds.get(stock.getUUID());
+
+            if(soundTrio == null) {
+                soundTrio = new Sounds();
+                soundTrio.start = startCreate != null ? startCreate.apply(stock) : null;
+                soundTrio.loop = loopCreate != null ? loopCreate.apply(stock) : null;
+                soundTrio.end = endCreate != null ? endCreate.apply(stock) : null;
+                sounds.put(stock.getUUID(), soundTrio);
             }
+            ISound startSound = soundTrio.start;
+            ISound loopSound = soundTrio.loop;
+            ISound endSound = soundTrio.end; //Unused for now
 
             if (volume > 0) {
-                sound.setPosition(stock.getPosition());
-                sound.setVelocity(stock.getVelocity());
-                sound.setVolume(volume);
-                sound.setPitch(pitch);
+                if(startSound != null) {
+                    startSound.setPosition(stock.getPosition());
+                    startSound.setVelocity(stock.getVelocity());
+                    startSound.setVolume(volume);
+                    startSound.setPitch(pitch);
 
-                if (!sound.isPlaying()) {
-                    sound.play(stock.getPosition());
-                } else {
-                    sound.update();
+                    if(!startSound.isPlaying() && !startHasPlayed) { //If nothing has started yet
+                        startSound.play(stock.getPosition());
+                        startIsPlaying = true;
+                    } else if (!startSound.isPlaying() && startIsPlaying) { //Start sound is done playing one take
+                        startHasPlayed = true;
+                        startIsPlaying = false;
+                        startSound.stop();
+                    } else {
+                        startSound.update();
+                    }
+                }
+                if(startHasPlayed || startSound == null) { //Once start has played, move on to loop
+                    loopSound.setPosition(stock.getPosition());
+                    loopSound.setVelocity(stock.getVelocity());
+                    loopSound.setVolume(volume);
+                    loopSound.setPitch(pitch);
+
+                    if(!loopSound.isPlaying())
+                    {
+                        loopSound.play(stock.getPosition());
+                    } else {
+                        loopSound.update();
+                    }
                 }
             } else {
-                if (sound.isPlaying()) {
-                    sound.stop();
+                if (startSound != null && startSound.isPlaying()) {
+                    startSound.stop();
                 }
+                if (loopSound != null && loopSound.isPlaying()) {
+                    loopSound.stop();
+                }
+                if (endSound != null && endSound.isPlaying()) {
+                    endSound.stop();
+                }
+                startHasPlayed = false;
+                endHasPlayed = false; //Probably needs to be somewhere else when endSound has usage
             }
         }
     }
 
     public void removed(EntityMoveableRollingStock stock) {
-        ISound sound = sounds.get(stock.getUUID());
-        if (sound != null) {
-            sound.terminate();
+        Sounds soundTrio = sounds.get(stock.getUUID());
+        if (soundTrio != null) {
+            if(soundTrio.start != null){ soundTrio.start.terminate();}
+            if(soundTrio.loop != null){ soundTrio.loop.terminate();}
+            if(soundTrio.end != null){ soundTrio.end.terminate();}
         }
     }
 

--- a/src/main/java/cam72cam/immersiverailroading/model/part/PartSound.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/PartSound.java
@@ -34,9 +34,9 @@ public class PartSound {
     private final ExpireableMap<UUID, Sounds> sounds = new ExpireableMap<UUID, Sounds>() {
         @Override
         public void onRemove(UUID key, Sounds value) {
-            value.start.terminate();
-            value.loop.terminate();
-            value.end.terminate();
+            if(value.start != null){ value.start.terminate();}
+            if(value.loop != null){ value.loop.terminate();}
+            if(value.end != null){ value.end.terminate();}
         }
     };
 

--- a/src/main/java/cam72cam/immersiverailroading/model/part/PartSound.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/PartSound.java
@@ -14,9 +14,9 @@ public class PartSound {
     private final Function<EntityMoveableRollingStock, ISound> endCreate;
 
     public PartSound(Function<EntityMoveableRollingStock, ISound> loopCreate)
-    { this.startCreate = null; this.loopCreate = loopCreate; this.endCreate = null;}
+    { this(null, loopCreate, null);}
     public PartSound(Function<EntityMoveableRollingStock, ISound> startCreate, Function<EntityMoveableRollingStock, ISound> loopCreate)
-    { this.startCreate = startCreate; this.loopCreate = loopCreate; this.endCreate = null;}
+    { this(startCreate, loopCreate, null);}
     public PartSound(Function<EntityMoveableRollingStock, ISound> startCreate, Function<EntityMoveableRollingStock, ISound> loopCreate, Function<EntityMoveableRollingStock, ISound> endCreate)
     { this.startCreate = startCreate; this.loopCreate = loopCreate; this.endCreate = endCreate;}
 
@@ -104,6 +104,7 @@ public class PartSound {
                 if (endSound != null && endSound.isPlaying()) {
                     endSound.stop();
                 }
+                startIsPlaying = false;
                 startHasPlayed = false;
                 endHasPlayed = false; //Probably needs to be somewhere else when endSound has usage
             }
@@ -111,12 +112,7 @@ public class PartSound {
     }
 
     public void removed(EntityMoveableRollingStock stock) {
-        Sounds soundTrio = sounds.get(stock.getUUID());
-        if (soundTrio != null) {
-            if(soundTrio.start != null){ soundTrio.start.terminate();}
-            if(soundTrio.loop != null){ soundTrio.loop.terminate();}
-            if(soundTrio.end != null){ soundTrio.end.terminate();}
-        }
+        sounds.remove(stock.getUUID());
     }
 
 }

--- a/src/main/java/cam72cam/immersiverailroading/registry/LocomotiveDieselDefinition.java
+++ b/src/main/java/cam72cam/immersiverailroading/registry/LocomotiveDieselDefinition.java
@@ -15,10 +15,12 @@ import java.io.IOException;
 
 public class LocomotiveDieselDefinition extends LocomotiveDefinition {
     private static Identifier default_idle = new Identifier(ImmersiveRailroading.MODID, "sounds/diesel/default/idle.ogg");
+    private static Identifier default_start = new Identifier(ImmersiveRailroading.MODID, "sounds/diesel/default/start.ogg"); //Needs a CC-free default sound
     private static Identifier default_horn = new Identifier(ImmersiveRailroading.MODID, "sounds/diesel/default/horn.ogg");
     private static Identifier default_bell = new Identifier(ImmersiveRailroading.MODID, "sounds/diesel/default/bell.ogg");
 
     public Identifier idle;
+    public Identifier start;
     public Identifier horn;
     private FluidQuantity fuelCapacity;
     private int fuelEfficiency;
@@ -54,12 +56,17 @@ public class LocomotiveDieselDefinition extends LocomotiveDefinition {
         JsonObject sounds = data.has("sounds") ? data.get("sounds").getAsJsonObject() : null;
 
         idle = default_idle;
+        start = default_start;
         horn = default_horn;
         bell = default_bell;
 
         if(sounds != null){
             if (sounds.has("idle")) {
                 idle = new Identifier(ImmersiveRailroading.MODID, sounds.get("idle").getAsString()).getOrDefault(default_idle);
+            }
+
+            if (sounds.has("start")) {
+                start = new Identifier(ImmersiveRailroading.MODID, sounds.get("start").getAsString()).getOrDefault(default_start);
             }
 
             if (sounds.has("horn")) {

--- a/src/main/java/cam72cam/immersiverailroading/registry/LocomotiveDieselDefinition.java
+++ b/src/main/java/cam72cam/immersiverailroading/registry/LocomotiveDieselDefinition.java
@@ -15,7 +15,6 @@ import java.io.IOException;
 
 public class LocomotiveDieselDefinition extends LocomotiveDefinition {
     private static Identifier default_idle = new Identifier(ImmersiveRailroading.MODID, "sounds/diesel/default/idle.ogg");
-    private static Identifier default_start = new Identifier(ImmersiveRailroading.MODID, "sounds/diesel/default/start.ogg"); //Needs a CC-free default sound
     private static Identifier default_horn = new Identifier(ImmersiveRailroading.MODID, "sounds/diesel/default/horn.ogg");
     private static Identifier default_bell = new Identifier(ImmersiveRailroading.MODID, "sounds/diesel/default/bell.ogg");
 
@@ -56,7 +55,7 @@ public class LocomotiveDieselDefinition extends LocomotiveDefinition {
         JsonObject sounds = data.has("sounds") ? data.get("sounds").getAsJsonObject() : null;
 
         idle = default_idle;
-        start = default_start;
+        start = null;
         horn = default_horn;
         bell = default_bell;
 
@@ -66,7 +65,7 @@ public class LocomotiveDieselDefinition extends LocomotiveDefinition {
             }
 
             if (sounds.has("start")) {
-                start = new Identifier(ImmersiveRailroading.MODID, sounds.get("start").getAsString()).getOrDefault(default_start);
+                start = new Identifier(ImmersiveRailroading.MODID, sounds.get("start").getAsString());
             }
 
             if (sounds.has("horn")) {

--- a/src/main/java/cam72cam/immersiverailroading/render/ExpireableMap.java
+++ b/src/main/java/cam72cam/immersiverailroading/render/ExpireableMap.java
@@ -53,10 +53,20 @@ public class ExpireableMap<K,V> {
 	public void put(K key, V displayList) {
 		synchronized(this) {
 			if (displayList == null) {
-				map.remove(key);
+				remove(key);
 			} else {
 				mapUsage.put(key, timeS());
 				map.put(key, displayList);
+			}
+		}
+	}
+
+	public void remove(K key) {
+		synchronized(this) {
+			if(map.containsKey(key)) {
+				onRemove(key, map.get(key));
+				map.remove(key);
+				mapUsage.remove(key);
 			}
 		}
 	}


### PR DESCRIPTION
PartSound now has support for a start clip and (tentatively awaiting implementation) an end clip. New sound tag in json "start" which will play before the main engine loop upon starting a locomotive if present. I decided against making the start sound a default because even if you could find a good CC-free sound, it wouldn't sound good mixed with other pack's custom engine sounds, so it will be something modelers have to add themselves.