### PR TITLE
feat: add debug stick to set trains home points

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/IRItems.java
+++ b/src/main/java/cam72cam/immersiverailroading/IRItems.java
@@ -20,6 +20,7 @@ public class IRItems {
 	public static ItemRadioCtrlCard ITEM_RADIO_CONTROL_CARD = new ItemRadioCtrlCard();
 	public static ItemSwitchKey ITEM_SWITCH_KEY = new ItemSwitchKey();
 	public static ItemTrackExchanger ITEM_TRACK_EXCHANGER = new ItemTrackExchanger();
+	public static ItemDebugStick ITEM_DEBUG_STICK = new ItemDebugStick();
 
 	public static void register() {
 		// loads static classes and ctrs

--- a/src/main/java/cam72cam/immersiverailroading/ImmersiveRailroading.java
+++ b/src/main/java/cam72cam/immersiverailroading/ImmersiveRailroading.java
@@ -36,6 +36,7 @@ import cam72cam.mod.math.Vec3d;
 import cam72cam.mod.net.Packet;
 import cam72cam.mod.net.PacketDirection;
 import cam72cam.mod.render.*;
+import cam72cam.mod.render.opengl.MinecraftTexture;
 import cam72cam.mod.render.opengl.RenderState;
 import cam72cam.mod.resource.Identifier;
 import cam72cam.mod.sound.Audio;
@@ -139,6 +140,7 @@ public class ImmersiveRailroading extends ModCore.Mod {
 				ItemRender.register(IRItems.ITEM_RADIO_CONTROL_CARD, new Identifier(MODID, "items/radio_card"));
 				ItemRender.register(IRItems.ITEM_MANUAL, new Identifier(MODID, "items/engineerslexicon"));
 				ItemRender.register(IRItems.ITEM_TRACK_EXCHANGER, new TrackExchangerModel());
+				ItemRender.register(IRItems.ITEM_DEBUG_STICK,  new Identifier("minecraft", "items/stick"));
 
 				IEntityRender<EntityMoveableRollingStock> stockRender = new IEntityRender<EntityMoveableRollingStock>() {
 					@Override

--- a/src/main/java/cam72cam/immersiverailroading/entity/Locomotive.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/Locomotive.java
@@ -16,6 +16,7 @@ import cam72cam.mod.entity.Player;
 import cam72cam.mod.entity.sync.TagSync;
 import cam72cam.mod.item.ClickResult;
 import cam72cam.mod.serialization.StrictTagMapper;
+import cam72cam.mod.serialization.TagCompound;
 import cam72cam.mod.serialization.TagField;
 import cam72cam.mod.world.World;
 
@@ -284,6 +285,18 @@ public abstract class Locomotive extends FreightTank {
 				return true;
 		}
     }
+
+	@Override
+	public void load(TagCompound data) {
+		// if a train has a home we should reset the controls
+		if (homePosition != null) {
+			setThrottle(0);
+			setReverser(0);
+			setTrainBrake(0);
+			setIndependentBrake(0);
+		}
+		super.load(data);
+	}
 
     public ClickResult onClick(Player player, Player.Hand hand) {
 		if (player.getHeldItem(hand).is(IRItems.ITEM_RADIO_CONTROL_CARD) && player.hasPermission(Permissions.LOCOMOTIVE_CONTROL)) {

--- a/src/main/java/cam72cam/immersiverailroading/items/ItemDebugStick.java
+++ b/src/main/java/cam72cam/immersiverailroading/items/ItemDebugStick.java
@@ -1,0 +1,25 @@
+package cam72cam.immersiverailroading.items;
+
+import cam72cam.immersiverailroading.ImmersiveRailroading;
+import cam72cam.mod.item.CreativeTab;
+import cam72cam.mod.item.CustomItem;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ItemDebugStick extends CustomItem {
+
+	public ItemDebugStick() {
+		super(ImmersiveRailroading.MODID, "item_debug_stick");
+	}
+
+	@Override
+	public int getStackSize() {
+		return 1;
+	}
+
+	@Override
+	public List<CreativeTab> getCreativeTabs() {
+		return Collections.singletonList(ItemTabs.MAIN_TAB);
+	}
+}

--- a/src/main/java/cam72cam/immersiverailroading/library/ChatText.java
+++ b/src/main/java/cam72cam/immersiverailroading/library/ChatText.java
@@ -36,6 +36,8 @@ public enum ChatText {
 	SWITCH_RESET("switch_state.reset"),
 	SWITCH_CANT_RESET("switch_state.cant_reset"),
 	SWITCH_ALREADY_RESET("switch_state.already_reset"),
+	DEBUG_STICK_SAVE_POSITION("debug_stick.save_position"),
+	DEBUG_STICK_CLEAR_POSITION("debug_stick.clear_position"),
 	;
 	
 	private String value;

--- a/src/main/resources/assets/immersiverailroading/lang/en_US.lang
+++ b/src/main/resources/assets/immersiverailroading/lang/en_US.lang
@@ -19,6 +19,7 @@ item.immersiverailroading:item_golden_spike.name=Golden Spike
 item.immersiverailroading:item_radio_control_card.name=Train Radio-control Card
 item.immersiverailroading:item_switch_key.name=Switch Key
 item.immersiverailroading:item_track_exchanger.name=Track Exchanger
+item.immersiverailroading:item_debug_stick.name=Debug Stick
 
 tile.immersiverailroading:block_rail.name=Rail
 tile.immersiverailroading:block_rail_gag.name=Rail (Gag)
@@ -61,6 +62,9 @@ chat.immersiverailroading:switch_state.locked=Switch locked to %s
 chat.immersiverailroading:switch_state.reset=The last-locked switch has been wirelessly unlocked!
 chat.immersiverailroading:switch_state.cant_reset=You haven't locked any switches with this key!
 chat.immersiverailroading:switch_state.already_reset=The last-locked switch is already unlocked!
+chat.immersiverailroading:debug_stick.save_position=Saved home position
+chat.immersiverailroading:debug_stick.clear_position=Cleared home position
+
 
 gui.immersiverailroading:label.brake=Brake
 gui.immersiverailroading:label.throttle=Throttle


### PR DESCRIPTION
Add a new Item that is only obtainable in the creative inventory to set trains home locations.
When a location is set the train is teleported there when loaded.
This is useful for automated setups to recover when a server crashes.