### PR TITLE
Consist threading (on top of Flo's Phyics threading)

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/Config.java
+++ b/src/main/java/cam72cam/immersiverailroading/Config.java
@@ -197,6 +197,9 @@ public class Config {
 
 		@Comment("Number of physics threads to use, 0 = disabled (This is experimental and may cause issues)")
 		public static int physicsThreads = 0;
+
+		@Comment("Number of consist threads to use, 0 = disabled (This is experimental and may cause issues)")
+		public static int consistThreads = 0;
 	}
 
 	@Name("debug")

--- a/src/main/java/cam72cam/immersiverailroading/entity/physics/PhysicsThread.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/physics/PhysicsThread.java
@@ -1,4 +1,4 @@
-package cam72cam.immersiverailroading.physics;
+package cam72cam.immersiverailroading.entity.physics;
 
 import cam72cam.immersiverailroading.Config.ConfigPerformance;
 import cam72cam.immersiverailroading.ImmersiveRailroading;

--- a/src/main/java/cam72cam/immersiverailroading/entity/physics/Simulation.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/physics/Simulation.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 public class Simulation {
 
     public static boolean forceQuickUpdates = false;
+    public static boolean chunksStillLoading = false;
 
     /**
      * Performs physics simulation for all stock in the specified world.
@@ -312,15 +313,19 @@ public class Simulation {
 
         // Apply new states
         for (EntityCoupleableRollingStock stock : allStock) {
+            if (chunksStillLoading) {
+                ImmersiveRailroading.info("wooooo");
+            }
             stock.states = stateMaps.stream().map(m -> m.get(stock.getUUID())).filter(Objects::nonNull).collect(Collectors.toList());
             for (SimulationState state : stock.states) {
-                state.dirty = false;
+                state.dirty = chunksStillLoading;
             }
             stock.positions = stock.states.stream().map(TickPos::new).collect(Collectors.toList());
             if (tick % 20 == 0 || anyStartedDirty) {
                 new MRSSyncPacket(stock, stock.positions).sendToObserving(stock);
             }
         }
+        chunksStillLoading = false;
     }
 
     public static class BlockCollector {

--- a/src/main/java/cam72cam/immersiverailroading/entity/physics/Simulation.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/physics/Simulation.java
@@ -81,7 +81,7 @@ public class Simulation {
         int pass = (int) tickId;
 
         List<Map<UUID, SimulationState>> stateMaps = new ArrayList<>();
-        List<Vec3i> blocksAlreadyBroken = new ArrayList<>();
+        BlockCollector blocksAlreadyBroken = new BlockCollector();
 
         for (int i = 0; i < 40; i++) {
             stateMaps.add(new HashMap<>());
@@ -320,6 +320,22 @@ public class Simulation {
             stock.positions = stock.states.stream().map(TickPos::new).collect(Collectors.toList());
             if (tick % 20 == 0 || anyStartedDirty) {
                 new MRSSyncPacket(stock, stock.positions).sendToObserving(stock);
+            }
+        }
+    }
+
+    public static class BlockCollector {
+        private final List<Vec3i> blocks = new ArrayList<>();
+
+        public void addAll(List<Vec3i> blocksToBreak) {
+            synchronized (blocks) {
+                blocks.addAll(blocksToBreak);
+            }
+        }
+
+        public boolean contains(Vec3i bp) {
+            synchronized (blocks) {
+                return blocks.contains(bp);
             }
         }
     }

--- a/src/main/java/cam72cam/immersiverailroading/entity/physics/Simulation.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/physics/Simulation.java
@@ -6,7 +6,6 @@ import cam72cam.immersiverailroading.entity.physics.chrono.ChronoState;
 import cam72cam.immersiverailroading.entity.physics.chrono.ServerChronoState;
 import cam72cam.immersiverailroading.net.MRSSyncPacket;
 import cam72cam.immersiverailroading.physics.TickPos;
-import cam72cam.immersiverailroading.physics.PhysicsThread;
 import cam72cam.mod.math.Vec3d;
 import cam72cam.mod.math.Vec3i;
 import cam72cam.mod.world.World;

--- a/src/main/java/cam72cam/immersiverailroading/entity/physics/SimulationState.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/physics/SimulationState.java
@@ -162,7 +162,7 @@ public class SimulationState {
 
         calculateCouplerPositions();
 
-        calculateBlockCollisions(Collections.emptyList());
+        calculateBlockCollisions(new Simulation.BlockCollector());
         blocksToBreak = Collections.emptyList();
     }
 
@@ -214,7 +214,7 @@ public class SimulationState {
         }
     }
 
-    public void calculateBlockCollisions(List<Vec3i> blocksAlreadyBroken) {
+    public void calculateBlockCollisions(Simulation.BlockCollector blocksAlreadyBroken) {
         this.collidingBlocks = config.world.blocksInBounds(this.bounds);
         this.trackToUpdate = new ArrayList<>();
         this.interferingBlocks = new ArrayList<>();
@@ -236,7 +236,7 @@ public class SimulationState {
         }
     }
 
-    public SimulationState next(double distance, List<Vec3i> blocksAlreadyBroken) {
+    public SimulationState next(double distance, Simulation.BlockCollector blocksAlreadyBroken) {
         SimulationState next = new SimulationState(this);
         next.moveAlongTrack(distance);
         if (this.position.equals(next.position)) {

--- a/src/main/java/cam72cam/immersiverailroading/physics/MovementTrack.java
+++ b/src/main/java/cam72cam/immersiverailroading/physics/MovementTrack.java
@@ -35,6 +35,10 @@ public class MovementTrack {
 		};
 		
 		for (Vec3d pos : positions) {
+			if (Thread.currentThread().getName().contains("ImmersiveRailroading") && !world.isBlockLoaded(new Vec3i(pos))) {
+				// We can't load chunks on any of the "IR" threads
+				continue;
+			}
 			for (double height : heightSkew) {
 				ITrack te = ITrack.get(world, pos.add(0, height + (currentPosition.y%1), 0), true);
 				if (te != null && Gauge.from(te.getTrackGauge()) == Gauge.from(gauge)) {

--- a/src/main/java/cam72cam/immersiverailroading/physics/MovementTrack.java
+++ b/src/main/java/cam72cam/immersiverailroading/physics/MovementTrack.java
@@ -1,5 +1,6 @@
 package cam72cam.immersiverailroading.physics;
 
+import cam72cam.immersiverailroading.ImmersiveRailroading;
 import cam72cam.immersiverailroading.library.Gauge;
 import cam72cam.immersiverailroading.library.TrackItems;
 import cam72cam.immersiverailroading.tile.TileRail;
@@ -37,6 +38,7 @@ public class MovementTrack {
 		for (Vec3d pos : positions) {
 			if (Thread.currentThread().getName().contains("ImmersiveRailroading") && !world.isBlockLoaded(new Vec3i(pos))) {
 				// We can't load chunks on any of the "IR" threads
+				ImmersiveRailroading.warn("Unable to load chunks on custom IR threads!");
 				continue;
 			}
 			for (double height : heightSkew) {

--- a/src/main/java/cam72cam/immersiverailroading/physics/MovementTrack.java
+++ b/src/main/java/cam72cam/immersiverailroading/physics/MovementTrack.java
@@ -1,6 +1,7 @@
 package cam72cam.immersiverailroading.physics;
 
 import cam72cam.immersiverailroading.ImmersiveRailroading;
+import cam72cam.immersiverailroading.entity.physics.Simulation;
 import cam72cam.immersiverailroading.library.Gauge;
 import cam72cam.immersiverailroading.library.TrackItems;
 import cam72cam.immersiverailroading.tile.TileRail;
@@ -39,6 +40,7 @@ public class MovementTrack {
 			if (Thread.currentThread().getName().contains("ImmersiveRailroading") && !world.isBlockLoaded(new Vec3i(pos))) {
 				// We can't load chunks on any of the "IR" threads
 				ImmersiveRailroading.warn("Unable to load chunks on custom IR threads!");
+				Simulation.chunksStillLoading = true;
 				continue;
 			}
 			for (double height : heightSkew) {

--- a/src/main/java/cam72cam/immersiverailroading/physics/PhysicsThread.java
+++ b/src/main/java/cam72cam/immersiverailroading/physics/PhysicsThread.java
@@ -23,7 +23,7 @@ public class PhysicsThread {
     /**
      * The last job submitted to the physics thread by dimension id.
      */
-    private static final HashMap<Integer, Future<?>> lastJobs = new HashMap<Integer, Future<?>>();
+    private static final HashMap<Object, Future<?>> lastJobs = new HashMap<>();
 
     /**
      * Gets or creates the physics thread, if enabled, or null if disabled.

--- a/src/main/java/cam72cam/immersiverailroading/tile/TileRailBase.java
+++ b/src/main/java/cam72cam/immersiverailroading/tile/TileRailBase.java
@@ -8,6 +8,7 @@ import cam72cam.immersiverailroading.IRItems;
 import cam72cam.immersiverailroading.ImmersiveRailroading;
 import cam72cam.immersiverailroading.entity.*;
 import cam72cam.immersiverailroading.entity.EntityCoupleableRollingStock.CouplerType;
+import cam72cam.immersiverailroading.entity.physics.Simulation;
 import cam72cam.immersiverailroading.entity.physics.SimulationState;
 import cam72cam.immersiverailroading.items.ItemRailAugment;
 import cam72cam.immersiverailroading.items.ItemTrackExchanger;
@@ -273,6 +274,7 @@ public class TileRailBase extends BlockEntityTrackTickable implements IRedstoneP
 			if (!getWorld().isBlockLoaded(getParent())) {
 				// We can't load chunks on any of the "IR" threads
 				ImmersiveRailroading.warn("Unable to load chunks (getParentTile) on custom IR threads!");
+				Simulation.chunksStillLoading = true;
 				return null;
 			}
 		}

--- a/src/main/java/cam72cam/immersiverailroading/tile/TileRailBase.java
+++ b/src/main/java/cam72cam/immersiverailroading/tile/TileRailBase.java
@@ -267,6 +267,7 @@ public class TileRailBase extends BlockEntityTrackTickable implements IRedstoneP
 
 		if (Thread.currentThread().getName().contains("ImmersiveRailroading") && !getWorld().isBlockLoaded(getParent())) {
 			// We can't load chunks on any of the "IR" threads
+			ImmersiveRailroading.warn("Unable to load chunks on custom IR threads!");
 			return null;
 		}
 

--- a/src/main/java/cam72cam/immersiverailroading/tile/TileRailBase.java
+++ b/src/main/java/cam72cam/immersiverailroading/tile/TileRailBase.java
@@ -264,6 +264,12 @@ public class TileRailBase extends BlockEntityTrackTickable implements IRedstoneP
 		if (this.getParent() == null) {
 			return null;
 		}
+
+		if (Thread.currentThread().getName().contains("ImmersiveRailroading") && !getWorld().isBlockLoaded(getParent())) {
+			// We can't load chunks on any of the "IR" threads
+			return null;
+		}
+
 		TileRail te = getWorld().getBlockEntity(this.getParent(), TileRail.class);
 		if (te == null || te.info == null) {
 			return null;

--- a/src/main/java/cam72cam/immersiverailroading/util/SpawnUtil.java
+++ b/src/main/java/cam72cam/immersiverailroading/util/SpawnUtil.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import cam72cam.immersiverailroading.entity.EntityCoupleableRollingStock;
 import cam72cam.immersiverailroading.entity.EntityRollingStock;
+import cam72cam.immersiverailroading.entity.physics.Simulation;
 import cam72cam.immersiverailroading.entity.physics.SimulationState;
 import cam72cam.immersiverailroading.items.ItemRollingStock;
 import cam72cam.immersiverailroading.library.ChatText;
@@ -52,7 +53,7 @@ public class SpawnUtil {
 				for (int i = 0; i <= 90; i+= 5) {
 					for (int j = -1; j <= 1; j += 2) {
 						ecrs.setRotationYaw(yaw + i * j);
-						SimulationState state = new SimulationState(ecrs).next(offset, new ArrayList<>());
+						SimulationState state = new SimulationState(ecrs).next(offset, new Simulation.BlockCollector());
 						if (state.position.distanceTo(ecrs.getPosition()) > offset/2) {
 							ecrs.setPosition(state.position);
 							ecrs.setRotationYaw(state.yaw);

--- a/src/main/java/cam72cam/immersiverailroading/util/SwitchUtil.java
+++ b/src/main/java/cam72cam/immersiverailroading/util/SwitchUtil.java
@@ -1,6 +1,7 @@
 package cam72cam.immersiverailroading.util;
 
 import cam72cam.immersiverailroading.Config;
+import cam72cam.immersiverailroading.ImmersiveRailroading;
 import cam72cam.immersiverailroading.library.SwitchState;
 import cam72cam.immersiverailroading.library.TrackItems;
 import cam72cam.immersiverailroading.tile.TileRail;
@@ -66,6 +67,11 @@ public class SwitchUtil {
 		for (int x = -scale; x <= scale; x++) {
 			for (int z = -scale; z <= scale; z++) {
 				Vec3i gagPos = new Vec3i(redstoneOrigin.add(new Vec3d(x, 0, z)));
+				if (Thread.currentThread().getName().contains("ImmersiveRailroading") && !rail.getWorld().isBlockLoaded(gagPos)) {
+					// We can't load chunks on any of the "IR" threads
+					ImmersiveRailroading.warn("Unable to load chunks (isRailPowered) on custom IR threads!");
+					continue;
+				}
 				TileRailBase gagRail = rail.getWorld().getBlockEntity(gagPos, TileRailBase.class);
 				if (gagRail != null && (rail.getPos().equals(gagRail.getParent()) || gagRail.getReplaced() != null)) {
 					if (rail.getWorld().getRedstone(gagPos) > 0) {

--- a/src/main/java/cam72cam/immersiverailroading/util/SwitchUtil.java
+++ b/src/main/java/cam72cam/immersiverailroading/util/SwitchUtil.java
@@ -2,6 +2,7 @@ package cam72cam.immersiverailroading.util;
 
 import cam72cam.immersiverailroading.Config;
 import cam72cam.immersiverailroading.ImmersiveRailroading;
+import cam72cam.immersiverailroading.entity.physics.Simulation;
 import cam72cam.immersiverailroading.library.SwitchState;
 import cam72cam.immersiverailroading.library.TrackItems;
 import cam72cam.immersiverailroading.tile.TileRail;
@@ -70,6 +71,7 @@ public class SwitchUtil {
 				if (Thread.currentThread().getName().contains("ImmersiveRailroading") && !rail.getWorld().isBlockLoaded(gagPos)) {
 					// We can't load chunks on any of the "IR" threads
 					ImmersiveRailroading.warn("Unable to load chunks (isRailPowered) on custom IR threads!");
+					Simulation.chunksStillLoading = true;
 					continue;
 				}
 				TileRailBase gagRail = rail.getWorld().getBlockEntity(gagPos, TileRailBase.class);


### PR DESCRIPTION
This is an extension on top of the work done in https://github.com/TeamOpenIndustry/ImmersiveRailroading/pull/1372

It allows each distinct "consist" to be calculated in parallel, further breaking up the tasks required by IR's physics in each world.

Original Code:
PreWorldTick -> each world -> setup physics -> calculate consist -> send update

Flo's PR:
PreWorldTick -> each world -> submit physics thread job (no further impact on TPS)
each physics thread job -> setup physics -> calculate consist -> send update

This PR:
PreWorldTick -> each world -> setup physics -> submit consist thread jobs
(calling thread waits)
each consist thread job -> calculate consist
(calling thread continues)
combine consists -> send update


tl;dr:
Flo's PR shunts all of the physics, consist, and (depending on MC) update message serialization onto it's own per-world thread so it does not impact TPS
This PR calculates each consist in parallel (up to the configured thread limit) which means each physics iteration is faster.
Together it means no TPS impact + more capacity for lots of trains running at the same time.


