### PR TITLE
Performance changes to server physics simulation

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/Config.java
+++ b/src/main/java/cam72cam/immersiverailroading/Config.java
@@ -272,6 +272,10 @@ public class Config {
 		@Comment("Warn if a physics tick takes more than the given time in ms")
 		@Range(min = 1, max = 100)
 		public static long physicsWarnThresholdMs = 20;
+
+		@Comment("Warn if a physics total iteration takes more than the given time in ms")
+		@Range(min = 1, max = 100)
+		public static long physicsWarnTotalThresholdMs = 40;
     }
 
 	public static boolean isFuelRequired(Gauge gauge) {

--- a/src/main/java/cam72cam/immersiverailroading/Config.java
+++ b/src/main/java/cam72cam/immersiverailroading/Config.java
@@ -271,11 +271,15 @@ public class Config {
 		public static boolean defaultAugmentComputer = false;
 		@Comment("Warn if a physics tick takes more than the given time in ms")
 		@Range(min = 1, max = 100)
-		public static long physicsWarnThresholdMs = 20;
+		public static int physicsWarnThresholdMs = 20;
 
 		@Comment("Warn if a physics total iteration takes more than the given time in ms")
 		@Range(min = 1, max = 100)
-		public static long physicsWarnTotalThresholdMs = 40;
+		public static int physicsWarnTotalThresholdMs = 40;
+
+		@Comment("Number of physics steps to cache for future movement / send in packets.  DO NOT CHANGE UNLESS YOU KNOW WHAT YOU ARE DOING")
+		@Range(min = 10, max = 60)
+		public static int physicsFutureTicks = 10;
     }
 
 	public static boolean isFuelRequired(Gauge gauge) {

--- a/src/main/java/cam72cam/immersiverailroading/entity/EntityCoupleableRollingStock.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/EntityCoupleableRollingStock.java
@@ -85,6 +85,11 @@ public abstract class EntityCoupleableRollingStock extends EntityMoveableRolling
 	@TagField(value = "consist", mapper = Consist.TagMapper.class)
 	public Consist consist = new Consist(Collections.emptyList(), Collections.emptyList());
 
+    @TagField("lastKnownFront")
+    public Vec3i lastKnownFront = null;
+	@TagField("lastKnownRear")
+	public Vec3i lastKnownRear = null;
+
 	@TagSync
 	@TagField("hasElectricalPower")
 	private boolean hasElectricalPower;
@@ -192,6 +197,23 @@ public abstract class EntityCoupleableRollingStock extends EntityMoveableRolling
 			setCoupledUUID(CouplerType.FRONT, state.interactingFront);
 			setCoupledUUID(CouplerType.BACK, state.interactingRear);
 			consist = state.consist;
+
+			if (getCoupledUUID(CouplerType.FRONT) != null) {
+				EntityCoupleableRollingStock front = getCoupled(CouplerType.FRONT);
+				if (front != null) {
+					lastKnownFront = front.getBlockPosition();
+				}
+			} else {
+				lastKnownFront = null;
+			}
+			if (getCoupledUUID(CouplerType.BACK) != null) {
+				EntityCoupleableRollingStock rear = getCoupled(CouplerType.BACK);
+				if (rear != null) {
+					lastKnownRear = rear.getBlockPosition();
+				}
+			} else {
+				lastKnownRear = null;
+			}
 		}
 	}
 

--- a/src/main/java/cam72cam/immersiverailroading/entity/EntityCoupleableRollingStock.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/EntityCoupleableRollingStock.java
@@ -181,7 +181,7 @@ public abstract class EntityCoupleableRollingStock extends EntityMoveableRolling
 
 		hadElectricalPower = hasElectricalPower();
 
-		if (this.getCurrentState() != null && !this.getCurrentState().canBeUnloaded || ConfigDebug.keepStockLoaded) {
+		if (this.getCurrentState() != null && !this.getCurrentState().atRest || ConfigDebug.keepStockLoaded) {
 			keepLoaded();
 		}
 

--- a/src/main/java/cam72cam/immersiverailroading/entity/EntityCoupleableRollingStock.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/EntityCoupleableRollingStock.java
@@ -114,8 +114,8 @@ public abstract class EntityCoupleableRollingStock extends EntityMoveableRolling
 					player.sendMessage(ChatText.COUPLER_DISENGAGED.getMessage(coupler));
 				}
 			} else {
-				if (this.isCoupled(coupler) && this.isCouplerEngaged(coupler)) {
-					EntityCoupleableRollingStock coupled = this.getCoupled(coupler);
+				EntityCoupleableRollingStock coupled = this.getCoupled(coupler);
+				if (this.isCoupled(coupler) && this.isCouplerEngaged(coupler) && coupled != null) {
 					player.sendMessage(ChatText.COUPLER_STATUS_COUPLED.getMessage(
 							coupler,
 							coupled.getDefinition().name(),

--- a/src/main/java/cam72cam/immersiverailroading/entity/EntityCoupleableRollingStock.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/EntityCoupleableRollingStock.java
@@ -121,7 +121,6 @@ public abstract class EntityCoupleableRollingStock extends EntityMoveableRolling
 				}
 			} else {
 				EntityCoupleableRollingStock coupled = this.getCoupled(coupler);
-				System.out.println(this.getCoupledUUID(coupler));
 				if (this.isCoupled(coupler) && this.isCouplerEngaged(coupler) && coupled != null) {
 					player.sendMessage(ChatText.COUPLER_STATUS_COUPLED.getMessage(
 							coupler,

--- a/src/main/java/cam72cam/immersiverailroading/entity/EntityMoveableRollingStock.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/EntityMoveableRollingStock.java
@@ -58,6 +58,8 @@ public abstract class EntityMoveableRollingStock extends EntityRidableRollingSto
 
     public long lastCollision = 0;
 
+    public boolean newlyPlaced = false;
+
     @Override
     public void load(TagCompound data) {
         super.load(data);

--- a/src/main/java/cam72cam/immersiverailroading/entity/physics/Consist.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/physics/Consist.java
@@ -525,7 +525,7 @@ public class Consist {
                 consist.forEach(p -> p.state.dirty = true);
             }
 
-            if (atRest) {
+            if (atRest && !dirty) {
                 // Copy existing states
                 for (Particle particle : consist) {
                     nextStateMap.put(particle.state.config.id, particle.state.next());

--- a/src/main/java/cam72cam/immersiverailroading/entity/physics/Consist.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/physics/Consist.java
@@ -634,7 +634,6 @@ public class Consist {
         public TagAccessor<Consist> apply(Class<Consist> type, String fieldName, TagField tag) throws SerializationException {
             return new TagAccessor<Consist>(
                     (d, o) -> {
-                        System.out.println("WRITE CONSIST");
                         if (o != null) {
                             d.set(fieldName, new TagCompound()
                                     .setList("ids", o.ids, u -> new TagCompound().setUUID("id", u))
@@ -643,13 +642,10 @@ public class Consist {
                         }
                     },
                     // TODO we could fallback to lastKnownFront/Rear
-                    d -> {
-                        System.out.println("READ CONSIST");
-                        return d.hasKey(fieldName) ? new Consist(
-                                d.get(fieldName).getList("ids", t -> t.getUUID("id")),
-                                d.get(fieldName).getList("pos", t -> t.getVec3i("p"))
-                        ) : new Consist(Collections.emptyList(), Collections.emptyList());
-                    }
+                    d -> d.hasKey(fieldName) ? new Consist(
+                            d.get(fieldName).getList("ids", t -> t.getUUID("id")),
+                            d.get(fieldName).getList("pos", t -> t.getVec3i("p"))
+                    ) : new Consist(Collections.emptyList(), Collections.emptyList())
             ) {
                 @Override
                 public boolean applyIfMissing() {

--- a/src/main/java/cam72cam/immersiverailroading/entity/physics/Consist.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/physics/Consist.java
@@ -523,9 +523,13 @@ public class Consist {
                 for (Particle particle : consist) {
                     nextStateMap.put(particle.state.config.id, particle.state.next());
                 }
+                Simulation.restStates += consist.size();
             } else {
                 if (dirty || missingNextStates) {
                     particles.addAll(consist);
+                    Simulation.calculatedStates += consist.size();
+                } else {
+                    Simulation.keptStates += consist.size();
                 }
             }
 

--- a/src/main/java/cam72cam/immersiverailroading/entity/physics/Consist.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/physics/Consist.java
@@ -468,6 +468,13 @@ public class Consist {
 
             // Propogate brake pressure
 
+
+            for (Particle particle : consist) {
+                if (particle.nextLink != null) {
+                    particle.nextLink.setup();
+                }
+            }
+
             List<SimulationState> linked = new ArrayList<>();
             for (Particle source : consist) {
                 linked.add(source.state);
@@ -550,12 +557,6 @@ public class Consist {
         double ticksPerSecond = 20;
         double stepsPerTick = 40;
         double dt_S = (1 / (ticksPerSecond * stepsPerTick));
-
-        for (Particle particle : particles) {
-            if (particle.nextLink != null) {
-                particle.nextLink.setup();
-            }
-        }
 
 
 

--- a/src/main/java/cam72cam/immersiverailroading/entity/physics/Consist.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/physics/Consist.java
@@ -5,10 +5,8 @@ import cam72cam.immersiverailroading.ImmersiveRailroading;
 import cam72cam.immersiverailroading.util.Speed;
 import cam72cam.mod.math.Vec3d;
 import cam72cam.mod.math.Vec3i;
-import cam72cam.mod.serialization.SerializationException;
 import cam72cam.mod.serialization.TagCompound;
 import cam72cam.mod.serialization.TagField;
-import cam72cam.mod.serialization.TagMapper;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -631,7 +629,7 @@ public class Consist {
 
     public static class TagMapper implements cam72cam.mod.serialization.TagMapper<Consist> {
         @Override
-        public TagAccessor<Consist> apply(Class<Consist> type, String fieldName, TagField tag) throws SerializationException {
+        public TagAccessor<Consist> apply(Class<Consist> type, String fieldName, TagField tag) {
             return new TagAccessor<Consist>(
                     (d, o) -> {
                         if (o != null) {

--- a/src/main/java/cam72cam/immersiverailroading/entity/physics/Simulation.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/physics/Simulation.java
@@ -22,6 +22,324 @@ public class Simulation {
     public static int restStates;
     public static int keptStates;
 
+    double maxCouplerDist = 4;
+
+    private final World world;
+    private final int startTickID;
+    List<Map<UUID, SimulationState>> stateMaps;
+    private final List<Vec3i> blocksAlreadyBroken;
+    List<EntityCoupleableRollingStock> loaded;
+
+
+    public Simulation(World world) {
+        this.world = world;
+        this.startTickID = ((ServerChronoState)ChronoState.getState(world)).getServerTickID();
+
+        stateMaps = new ArrayList<>();
+        blocksAlreadyBroken = new ArrayList<>();
+
+        for (int i = 0; i < Config.ConfigDebug.physicsFutureTicks; i++) {
+            stateMaps.add(new HashMap<>());
+        }
+
+        for (int i = 0; i < stateMaps.size()-1; i++) {
+            simulateTick(i);
+        }
+
+        boolean sendPackets = world.getTicks() % (Config.ConfigDebug.physicsFutureTicks / 2) == 0;
+        double syncDistanceSq = ImmersiveRailroading.ENTITY_SYNC_DISTANCE * ImmersiveRailroading.ENTITY_SYNC_DISTANCE;
+        List<Player> players = sendPackets ? world.getEntities(Player.class) : null;
+
+        // Apply new states
+        for (EntityCoupleableRollingStock stock : loaded) {
+            stock.states = stateMaps.stream().map(m -> m.get(stock.getUUID())).filter(Objects::nonNull).collect(Collectors.toList());
+            for (SimulationState state : stock.states) {
+                state.dirty = false;
+            }
+            stock.positions = stock.states.stream().map(TickPos::new).collect(Collectors.toList());
+            if (sendPackets && players.stream().anyMatch(player -> player.getPosition().distanceToSquared(stock.getPosition()) < syncDistanceSq)) {
+                new MRSSyncPacket(stock, stock.positions).sendToObserving(stock);
+            }
+        }
+    }
+
+    public void simulateTick(int iteration) {
+        int tickID = startTickID + iteration;
+
+        Map<UUID, SimulationState> stateMap = stateMaps.get(iteration);
+        Map<UUID, SimulationState> nextStateMap = stateMaps.get(iteration+1);
+
+        // Should really only ever run once, maybe twice.  Cut it off after 10 times just to be safe
+        for (int tryLoad = 0; tryLoad < 10; tryLoad++) {
+            // If this is too slow, we could hang onto the list of stock that is at rest.
+            // We should only need to do this when stock is no longer at rest or changes dirty flag
+            loaded = world.getEntities(EntityCoupleableRollingStock.class);
+
+            boolean newChunksLoaded = false;
+            for (EntityCoupleableRollingStock stock : loaded) {
+
+                if (!stateMap.containsKey(stock.getUUID())) {
+                    if (stock.states.isEmpty()) {
+                        SimulationState state = new SimulationState(stock);
+                        state.tickID = tickID;
+                        stateMap.put(stock.getUUID(), state);
+                    } else {
+                        for (SimulationState state : stock.states) {
+                            int stateIteration = state.tickID - tickID;
+                            if (stateIteration >= 0) {
+                                state.update(stock);
+                                stateMaps.get(stateIteration).put(stock.getUUID(), state);
+                            }
+                        }
+                    }
+                }
+
+                SimulationState state = stateMap.get(stock.getUUID());
+
+
+                // Don't need to load
+                if (state.atRest && !state.dirty) {
+                    continue;
+                }
+
+                // Keep it loaded
+                world.keepLoaded(new Vec3i(state.position));
+
+                if (state.consist.positions == null) {
+                    continue;
+                }
+
+                // Load interacting stock locations
+                // We could in the future do a HashSet<Consist> and reduce the calls to the world.
+                for (Vec3i pos : state.consist.positions) {
+                    if (!world.isBlockLoaded(pos)) {
+                        ImmersiveRailroading.debug("Loading chunk at position %s", pos);
+                        // Load the chunk, entities should be directly injected into the world
+                        world.getBlock(pos);
+                        newChunksLoaded = true;
+                    }
+                }
+            }
+            if (!newChunksLoaded) {
+                break;
+            }
+        }
+
+        List<SimulationState> states = new ArrayList<>(stateMap.values());
+
+        // Propagate dirty (even across links that will be since that can change between iterations)
+        Set<UUID> dirty = new HashSet<>();
+        for (SimulationState state : nextStateMap.values()) { // I don't remember why this is the next map
+            if (state.dirty) {
+                dirty.addAll(state.consist.ids);
+            }
+        }
+        for (UUID uuid : dirty) {
+            SimulationState state = stateMap.get(uuid);
+            if (state != null) {
+                state.dirty = true;
+            }
+        }
+
+        // Decouple / fix coupler positions
+        for (SimulationState state : states) {
+            for (boolean isMyCouplerFront : new boolean[]{true, false}) {
+                UUID myID = state.config.id;
+                UUID otherID = isMyCouplerFront ? state.interactingFront : state.interactingRear;
+                Vec3d myCouplerPos = isMyCouplerFront ? state.couplerPositionFront : state.couplerPositionRear;
+                String myCouplerLabel = isMyCouplerFront ? "Front" : "Rear";
+
+                if (otherID == null) {
+                    // No existing coupler, nothing to check
+                    continue;
+                }
+                SimulationState other = stateMap.get(otherID);
+                if (other == null) {
+
+                    // Don't need to load
+                    if (state.atRest && !state.dirty) {
+                        continue;
+                    }
+
+                    ImmersiveRailroading.debug("%s-%s: Stock not found %s (%s) -> %s!",
+                            startTickID, state.tickID, myID, myCouplerLabel, otherID);
+                    if (isMyCouplerFront) {
+                        state.interactingFront = null;
+                    } else {
+                        state.interactingRear = null;
+                    }
+                    state.dirty = true;
+                    continue;
+                }
+
+                boolean isOtherCouplerFront;
+                if (myID.equals(other.interactingFront)) {
+                    isOtherCouplerFront = true;
+                } else if (myID.equals(other.interactingRear)) {
+                    isOtherCouplerFront = false;
+                } else {
+                    /*
+                    This can happen when a piece of stock is marked dirty (discard existing states ex: throttle/brake)
+                    and a piece of stock it couples with in the future states has not been marked dirty.  The dirty
+                    stock is starting from 0, while the one it has future coupled to in a previous pass (that's english right?)
+                    does not know until this re-check that it has desync'd at this point and must generate new states
+                    from here on out in this pass.
+
+                    This should be fixed with the smarter "dirty" logic above
+                     */
+                    ImmersiveRailroading.warn("%s-%s: Mismatched coupler states: %s (%s) -> %s (%s, %s)",
+                            startTickID, state.tickID,
+                            myID, myCouplerLabel,
+                            otherID, other.interactingFront, other.interactingRear);
+                    if (isMyCouplerFront) {
+                        state.interactingFront = null;
+                    } else {
+                        state.interactingRear = null;
+                    }
+                    state.dirty = true;
+                    other.dirty = true;
+                    continue;
+                }
+
+                Vec3d otherCouplerPos = isOtherCouplerFront ? other.couplerPositionFront : other.couplerPositionRear;
+                String otherCouplerLabel = isOtherCouplerFront ? "Front" : "Rear";
+
+                double maxCouplerDistScaled = maxCouplerDist * state.config.gauge.scale();
+                if (myCouplerPos.distanceToSquared(otherCouplerPos) > maxCouplerDistScaled * maxCouplerDistScaled) {
+                    ImmersiveRailroading.debug("%s-%s: Coupler snapping due to distance: %s (%s) -> %s (%s)",
+                            startTickID, state.tickID,
+                            myID, myCouplerLabel,
+                            otherID, otherCouplerLabel);
+                    state.dirty = true;
+                    other.dirty = true;
+
+                    if (isMyCouplerFront) {
+                        state.interactingFront = null;
+                    } else {
+                        state.interactingRear = null;
+                    }
+
+                    if (isOtherCouplerFront) {
+                        other.interactingFront = null;
+                    } else {
+                        other.interactingRear = null;
+                    }
+                }
+            }
+        }
+
+
+        // check for potential couplings and collisions
+        for (int sai = 0; sai < states.size()-1; sai++) {
+            SimulationState stateA = states.get(sai);
+            if (stateA.interactingFront != null && stateA.interactingRear != null) {
+                // There's stock in front and behind, can't really hit any other stock here
+                continue;
+            }
+
+            for (int sbi = sai+1; sbi < states.size(); sbi++) {
+                SimulationState stateB = states.get(sbi);
+                if (stateA.atRest && stateB.atRest) {
+                    continue;
+                }
+                if (stateB.interactingFront != null && stateB.interactingRear != null) {
+                    // There's stock in front and behind, can't really hit any other stock here
+                    continue;
+                }
+
+                if (stateA.config.gauge != stateB.config.gauge) {
+                    // Same gauge required
+                    continue;
+                }
+
+                double centerDist = stateA.config.length + stateB.config.length;
+                if (stateA.position.distanceToSquared(stateB.position) > centerDist * centerDist) {
+                    // Too far to reasonably couple
+                    continue;
+                }
+
+                if (!stateA.bounds.intersects(stateB.bounds)) {
+                    // Not close enough to couple
+                    continue;
+                }
+
+                if (stateB.config.id.equals(stateA.interactingFront) || stateB.config.id.equals(stateA.interactingRear)) {
+                    // Already coupled
+                    continue;
+                }
+                if (stateA.config.id.equals(stateB.interactingFront) || stateA.config.id.equals(stateB.interactingRear)) {
+                    // Already coupled (double safe check)
+                    continue;
+                }
+
+                // At this point the stock are colliding / overlapping and we need to do something about it
+
+                /*
+                 * 1. |-----a-----| |-----b-----|
+                 * 2. |-----a---|=|----b-----|
+                 * 3. |---|=a====b|-----|
+                 * Keep in mind that we want to make sure that our other coupler might be a better fit
+                 */
+
+                // the coupler to target is whichever one the other's center is closest to
+                boolean targetACouplerFront =
+                        stateA.couplerPositionFront.distanceToSquared(stateB.position) <
+                                stateA.couplerPositionRear.distanceToSquared(stateB.position);
+                boolean targetBCouplerFront =
+                        stateB.couplerPositionFront.distanceToSquared(stateA.position) <
+                                stateB.couplerPositionRear.distanceToSquared(stateA.position);
+
+                // Best coupler is already coupled to something
+                if ((targetACouplerFront ? stateA.interactingFront : stateA.interactingRear) != null) {
+                    continue;
+                }
+                if ((targetBCouplerFront ? stateB.interactingFront : stateB.interactingRear) != null) {
+                    continue;
+                }
+
+                // Since bounding boxes can overlap across different tracks (think parallel curves) we need to do
+                // a more fine-grained check here
+                Vec3d couplerPosA = targetACouplerFront ? stateA.couplerPositionFront : stateA.couplerPositionRear;
+                Vec3d couplerPosB = targetBCouplerFront ? stateB.couplerPositionFront : stateB.couplerPositionRear;
+                // Move coupler pos up to inside the BB (it's at track level by default)
+                // This could be optimized further, but it's an infrequent calculation
+                couplerPosA = couplerPosA.add(0, stateB.bounds.max().subtract(stateB.bounds.min()).y/2, 0);
+                couplerPosB = couplerPosB.add(0, stateA.bounds.max().subtract(stateA.bounds.min()).y/2, 0);
+                if (!stateB.bounds.contains(couplerPosA) || !stateA.bounds.contains(couplerPosB)) {
+                    // Not actually on the same track, just a BB collision and can be ignored
+                    continue;
+                }
+
+                stateA.dirty = true;
+                stateB.dirty = true;
+                ImmersiveRailroading.debug("%s-%s: Coupling %s (%s) to %s (%s)",
+                        startTickID, stateA.tickID,
+                        stateA.config.id, targetACouplerFront ? "Front" : "Rear",
+                        stateB.config.id, targetBCouplerFront ? "Front" : "Rear");
+
+                // Ok, we are clear to proceed!
+                if (targetACouplerFront) {
+                    stateA.interactingFront = stateB.config.id;
+                } else {
+                    stateA.interactingRear = stateB.config.id;
+                }
+                if (targetBCouplerFront) {
+                    stateB.interactingFront = stateA.config.id;
+                } else {
+                    stateB.interactingRear = stateA.config.id;
+                }
+            }
+        }
+
+        // calculate new velocities
+        Consist.iterate(stateMap, nextStateMap, blocksAlreadyBroken);
+    }
+
+
+
+
+
+
     public static void simulate(World world) {
         // 100KM/h ~= 28m/s which means non-loaded stationary stock may be phased through at that speed
         // I'm OK with that for now
@@ -36,300 +354,6 @@ public class Simulation {
             forceQuickUpdates = false;
         }
 
-        List<EntityCoupleableRollingStock> allStock = world.getEntities(EntityCoupleableRollingStock.class);
-        if (allStock.isEmpty()) {
-            return;
-        }
-
-        if (ChronoState.getState(world).getTickID() < 20 * 2) {
-            // Wait for at least 2 seconds before starting simulation (for stock to load)
-            allStock.forEach(EntityCoupleableRollingStock::keepLoaded);
-            return;
-        }
-
-        long startMs = System.currentTimeMillis();
-        calculatedStates = 0;
-        restStates = 0;
-        keptStates = 0;
-
-        int pass = (int) ChronoState.getState(world).getTickID();
-
-        List<Map<UUID, SimulationState>> stateMaps = new ArrayList<>();
-        List<Vec3i> blocksAlreadyBroken = new ArrayList<>();
-
-        for (int i = 0; i < Config.ConfigDebug.physicsFutureTicks; i++) {
-            stateMaps.add(new HashMap<>());
-        }
-
-
-        ServerChronoState chrono = (ServerChronoState) ChronoState.getState(world);
-
-        for (EntityCoupleableRollingStock entity : allStock) {
-            SimulationState current = entity.getCurrentState();
-            if (current == null) {
-                // Newly placed
-                stateMaps.get(0).put(entity.getUUID(), new SimulationState(entity));
-            } else {
-                // Copy from previous simulation
-                for (SimulationState state : entity.states) {
-                    int i = state.tickID - chrono.getServerTickID();
-                    if (i >= 0) {
-                        state.update(entity);
-                        stateMaps.get(i).put(entity.getUUID(), state);
-                    }
-                }
-            }
-        }
-
-        boolean anyStartedDirty = stateMaps.get(0).values().stream().anyMatch(x -> x.dirty);
-
-        double maxCouplerDist = 4;
-
-        long startStatesMs = System.currentTimeMillis();
-
-        for (int i = 0; i < stateMaps.size()-1; i++) {
-            long startIterationMs = System.currentTimeMillis();
-
-            Map<UUID, SimulationState> stateMap = stateMaps.get(i);
-            Map<UUID, SimulationState> nextStateMap = stateMaps.get(i+1);
-
-            List<SimulationState> states = new ArrayList<>(stateMap.values());
-
-            // Propagate dirty (even across links that will be since that can change between iterations)
-            Set<UUID> dirty = new HashSet<>();
-            for (SimulationState state : nextStateMap.values()) {
-                if (state.dirty) {
-                    dirty.addAll(state.consist);
-                }
-            }
-            for (UUID uuid : dirty) {
-                SimulationState state = stateMap.get(uuid);
-                if (state != null) {
-                    state.dirty = true;
-                }
-            }
-
-
-
-            // Decouple / fix coupler positions
-            for (SimulationState state : states) {
-                for (boolean isMyCouplerFront : new boolean[]{true, false}) {
-                    UUID myID = state.config.id;
-                    UUID otherID = isMyCouplerFront ? state.interactingFront : state.interactingRear;
-                    Vec3d myCouplerPos = isMyCouplerFront ? state.couplerPositionFront : state.couplerPositionRear;
-                    String myCouplerLabel = isMyCouplerFront ? "Front" : "Rear";
-
-                    if (otherID == null) {
-                        // No existing coupler, nothing to check
-                        continue;
-                    }
-
-                    if (state.atRest) {
-                        // Technically this is fired twice for each piece of coupled stock which isn't great
-                        continue;
-                    }
-
-                    SimulationState other = stateMap.get(otherID);
-                    if (other == null) {
-                        // Likely due to chunk loading?
-                        ImmersiveRailroading.debug("%s-%s: Unable to find coupled stock for %s (%s) -> %s!",
-                                pass, state.tickID, myID, myCouplerLabel, otherID);
-
-                        state.dirty = true;
-                        if (isMyCouplerFront) {
-                            state.interactingFront = null;
-                        } else {
-                            state.interactingRear = null;
-                        }
-                        continue;
-                    }
-
-                    boolean isOtherCouplerFront;
-                    if (myID.equals(other.interactingFront)) {
-                        isOtherCouplerFront = true;
-                    } else if (myID.equals(other.interactingRear)) {
-                        isOtherCouplerFront = false;
-                    } else {
-                        /*
-                        This can happen when a piece of stock is marked dirty (discard existing states ex: throttle/brake)
-                        and a piece of stock it couples with in the future states has not been marked dirty.  The dirty
-                        stock is starting from 0, while the one it has future coupled to in a previous pass (that's english right?)
-                        does not know until this re-check that it has desync'd at this point and must generate new states
-                        from here on out in this pass.
-
-                        This should be fixed with the smarter "dirty" logic above
-                         */
-                        ImmersiveRailroading.warn("%s-%s: Mismatched coupler states: %s (%s) -> %s (%s, %s)",
-                                pass, state.tickID,
-                                myID, myCouplerLabel,
-                                otherID, other.interactingFront, other.interactingRear);
-                        if (isMyCouplerFront) {
-                            state.interactingFront = null;
-                        } else {
-                            state.interactingRear = null;
-                        }
-                        state.dirty = true;
-                        other.dirty = true;
-                        continue;
-                    }
-
-                    Vec3d otherCouplerPos = isOtherCouplerFront ? other.couplerPositionFront : other.couplerPositionRear;
-                    String otherCouplerLabel = isOtherCouplerFront ? "Front" : "Rear";
-
-                    double maxCouplerDistScaled = maxCouplerDist * state.config.gauge.scale();
-                    if (myCouplerPos.distanceToSquared(otherCouplerPos) > maxCouplerDistScaled * maxCouplerDistScaled) {
-                        ImmersiveRailroading.debug("%s-%s: Coupler snapping due to distance: %s (%s) -> %s (%s)",
-                                pass, state.tickID,
-                                myID, myCouplerLabel,
-                                otherID, otherCouplerLabel);
-                        state.dirty = true;
-                        other.dirty = true;
-
-                        if (isMyCouplerFront) {
-                            state.interactingFront = null;
-                        } else {
-                            state.interactingRear = null;
-                        }
-
-                        if (isOtherCouplerFront) {
-                            other.interactingFront = null;
-                        } else {
-                            other.interactingRear = null;
-                        }
-                    }
-                }
-            }
-
-
-            // check for potential couplings and collisions
-            for (int sai = 0; sai < states.size()-1; sai++) {
-                SimulationState stateA = states.get(sai);
-                if (stateA.interactingFront != null && stateA.interactingRear != null) {
-                    // There's stock in front and behind, can't really hit any other stock here
-                    continue;
-                }
-
-                for (int sbi = sai+1; sbi < states.size(); sbi++) {
-                    SimulationState stateB = states.get(sbi);
-                    if (stateA.atRest && stateB.atRest) {
-                        continue;
-                    }
-                    if (stateB.interactingFront != null && stateB.interactingRear != null) {
-                        // There's stock in front and behind, can't really hit any other stock here
-                        continue;
-                    }
-
-                    if (stateA.config.gauge != stateB.config.gauge) {
-                        // Same gauge required
-                        continue;
-                    }
-
-                    double centerDist = stateA.config.length + stateB.config.length;
-                    if (stateA.position.distanceToSquared(stateB.position) > centerDist * centerDist) {
-                        // Too far to reasonably couple
-                        continue;
-                    }
-
-                    if (!stateA.bounds.intersects(stateB.bounds)) {
-                        // Not close enough to couple
-                        continue;
-                    }
-
-                    if (stateB.config.id.equals(stateA.interactingFront) || stateB.config.id.equals(stateA.interactingRear)) {
-                        // Already coupled
-                        continue;
-                    }
-                    if (stateA.config.id.equals(stateB.interactingFront) || stateA.config.id.equals(stateB.interactingRear)) {
-                        // Already coupled (double safe check)
-                        continue;
-                    }
-
-                    // At this point the stock are colliding / overlapping and we need to do something about it
-
-                    /*
-                     * 1. |-----a-----| |-----b-----|
-                     * 2. |-----a---|=|----b-----|
-                     * 3. |---|=a====b|-----|
-                     * Keep in mind that we want to make sure that our other coupler might be a better fit
-                     */
-
-                    // the coupler to target is whichever one the other's center is closest to
-                    boolean targetACouplerFront =
-                            stateA.couplerPositionFront.distanceToSquared(stateB.position) <
-                            stateA.couplerPositionRear.distanceToSquared(stateB.position);
-                    boolean targetBCouplerFront =
-                            stateB.couplerPositionFront.distanceToSquared(stateA.position) <
-                            stateB.couplerPositionRear.distanceToSquared(stateA.position);
-
-                    // Best coupler is already coupled to something
-                    if ((targetACouplerFront ? stateA.interactingFront : stateA.interactingRear) != null) {
-                        continue;
-                    }
-                    if ((targetBCouplerFront ? stateB.interactingFront : stateB.interactingRear) != null) {
-                        continue;
-                    }
-
-                    // Since bounding boxes can overlap across different tracks (think parallel curves) we need to do
-                    // a more fine-grained check here
-                    Vec3d couplerPosA = targetACouplerFront ? stateA.couplerPositionFront : stateA.couplerPositionRear;
-                    Vec3d couplerPosB = targetBCouplerFront ? stateB.couplerPositionFront : stateB.couplerPositionRear;
-                    // Move coupler pos up to inside the BB (it's at track level by default)
-                    // This could be optimized further, but it's an infrequent calculation
-                    couplerPosA = couplerPosA.add(0, stateB.bounds.max().subtract(stateB.bounds.min()).y/2, 0);
-                    couplerPosB = couplerPosB.add(0, stateA.bounds.max().subtract(stateA.bounds.min()).y/2, 0);
-                    if (!stateB.bounds.contains(couplerPosA) || !stateA.bounds.contains(couplerPosB)) {
-                        // Not actually on the same track, just a BB collision and can be ignored
-                        continue;
-                    }
-
-                    stateA.dirty = true;
-                    stateB.dirty = true;
-                    ImmersiveRailroading.debug("%s-%s: Coupling %s (%s) to %s (%s)",
-                            pass, stateA.tickID,
-                            stateA.config.id, targetACouplerFront ? "Front" : "Rear",
-                            stateB.config.id, targetBCouplerFront ? "Front" : "Rear");
-
-                    // Ok, we are clear to proceed!
-                    if (targetACouplerFront) {
-                        stateA.interactingFront = stateB.config.id;
-                    } else {
-                        stateA.interactingRear = stateB.config.id;
-                    }
-                    if (targetBCouplerFront) {
-                        stateB.interactingFront = stateA.config.id;
-                    } else {
-                        stateB.interactingRear = stateA.config.id;
-                    }
-                }
-            }
-
-            // calculate new velocities
-            Consist.iterate(stateMap, nextStateMap, blocksAlreadyBroken);
-
-            long iterationMs = System.currentTimeMillis() - startIterationMs;
-            if (iterationMs > Config.ConfigDebug.physicsWarnThresholdMs) {
-                ImmersiveRailroading.warn("Calculating Immersive Railroading Physics Iteration took %sms (dirty: %s, %s, %s, %s)", iterationMs, anyStartedDirty, calculatedStates, restStates, keptStates);
-            }
-        }
-        long totalMs = System.currentTimeMillis() - startMs;
-        if (totalMs > Config.ConfigDebug.physicsWarnTotalThresholdMs) {
-            ImmersiveRailroading.warn("Calculating Immersive Railroading Physics took %sms : %sms (dirty: %s, %s, %s, %s)", totalMs, System.currentTimeMillis() - startStatesMs, anyStartedDirty, calculatedStates, restStates, keptStates);
-        }
-
-        boolean sendPackets = world.getTicks() % (Config.ConfigDebug.physicsFutureTicks / 2) == 0 || anyStartedDirty;
-        double syncDistanceSq = ImmersiveRailroading.ENTITY_SYNC_DISTANCE * ImmersiveRailroading.ENTITY_SYNC_DISTANCE;
-        List<Player> players = sendPackets ? world.getEntities(Player.class) : null;
-
-        // Apply new states
-        for (EntityCoupleableRollingStock stock : allStock) {
-            stock.states = stateMaps.stream().map(m -> m.get(stock.getUUID())).filter(Objects::nonNull).collect(Collectors.toList());
-            for (SimulationState state : stock.states) {
-                state.dirty = false;
-            }
-            stock.positions = stock.states.stream().map(TickPos::new).collect(Collectors.toList());
-            if (sendPackets && players.stream().anyMatch(player -> player.getPosition().distanceToSquared(stock.getPosition()) < syncDistanceSq)) {
-                new MRSSyncPacket(stock, stock.positions).sendToObserving(stock);
-            }
-        }
+        new Simulation(world);
     }
 }

--- a/src/main/java/cam72cam/immersiverailroading/entity/physics/Simulation.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/physics/Simulation.java
@@ -155,12 +155,16 @@ public class Simulation {
                 }
                 SimulationState other = stateMap.get(otherID);
                 if (other == null) {
+                    Vec3i otherPos = loaded.stream()
+                            .filter(x -> x.getUUID().equals(myID)).findFirst()
+                            .map(x -> isMyCouplerFront ? x.lastKnownFront : x.lastKnownRear).orElse(null);
 
-                    // Don't need to load
-                    if (state.atRest && !state.dirty) {
+                    if (otherPos != null && !world.isBlockLoaded(otherPos)) {
+                        // Other location is not loaded, we must not need to do this check.
                         continue;
                     }
 
+                    // This should really only be hit when removing a piece of stock
                     ImmersiveRailroading.debug("%s-%s: Stock not found %s (%s) -> %s!",
                             startTickID, state.tickID, myID, myCouplerLabel, otherID);
                     if (isMyCouplerFront) {

--- a/src/main/java/cam72cam/immersiverailroading/entity/physics/Simulation.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/physics/Simulation.java
@@ -44,6 +44,7 @@ public class Simulation {
             return;
         }
 
+        long startMs = System.currentTimeMillis();
 
         int pass = (int) ChronoState.getState(world).getTickID();
 
@@ -95,8 +96,10 @@ public class Simulation {
 
         double maxCouplerDist = 4;
 
+        long startStatesMs = System.currentTimeMillis();
+
         for (int i = 0; i < stateMaps.size(); i++) {
-            long startMs = System.currentTimeMillis();
+            long startIterationMs = System.currentTimeMillis();
 
             Map<UUID, SimulationState> stateMap = stateMaps.get(i);
 
@@ -189,6 +192,7 @@ public class Simulation {
 
             // check for potential couplings and collisions
             for (int sai = 0; sai < states.size()-1; sai++) {
+
                 SimulationState stateA = states.get(sai);
                 if (stateA.interactingFront != null && stateA.interactingRear != null) {
                     // There's stock in front and behind, can't really hit any other stock here
@@ -290,10 +294,14 @@ public class Simulation {
                 stateMaps.get(i+1).putAll(Consist.iterate(stateMap, blocksAlreadyBroken));
             }
 
-            long totalMs = System.currentTimeMillis() - startMs;
-            if (totalMs > Config.ConfigDebug.physicsWarnThresholdMs) {
-                ImmersiveRailroading.warn("Calculating Immersive Railroading Physics took %sms (dirty: %s)", totalMs, anyStartedDirty);
+            long iterationMs = System.currentTimeMillis() - startIterationMs;
+            if (iterationMs > Config.ConfigDebug.physicsWarnThresholdMs) {
+                ImmersiveRailroading.warn("Calculating Immersive Railroading Physics Iteration took %sms (dirty: %s)", iterationMs, anyStartedDirty);
             }
+        }
+        long totalMs = System.currentTimeMillis() - startMs;
+        if (totalMs > Config.ConfigDebug.physicsWarnTotalThresholdMs) {
+            ImmersiveRailroading.warn("Calculating Immersive Railroading Physics took %sms : %sms (dirty: %s)", totalMs, System.currentTimeMillis() - startStatesMs, anyStartedDirty);
         }
 
         boolean sendPackets = world.getTicks() % 20 == 0 || anyStartedDirty;

--- a/src/main/java/cam72cam/immersiverailroading/entity/physics/Simulation.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/physics/Simulation.java
@@ -243,7 +243,7 @@ public class Simulation {
 
             for (int sbi = sai+1; sbi < states.size(); sbi++) {
                 SimulationState stateB = states.get(sbi);
-                if (stateA.atRest && stateB.atRest) {
+                if (stateA.atRest && stateB.atRest && !stateA.dirty && !stateB.dirty) {
                     continue;
                 }
                 if (stateB.interactingFront != null && stateB.interactingRear != null) {

--- a/src/main/java/cam72cam/immersiverailroading/entity/physics/Simulation.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/physics/Simulation.java
@@ -18,6 +18,9 @@ import java.util.stream.Collectors;
 public class Simulation {
 
     public static boolean forceQuickUpdates = false;
+    public static int calculatedStates;
+    public static int restStates;
+    public static int keptStates;
 
     public static void simulate(World world) {
         // 100KM/h ~= 28m/s which means non-loaded stationary stock may be phased through at that speed
@@ -45,6 +48,9 @@ public class Simulation {
         }
 
         long startMs = System.currentTimeMillis();
+        calculatedStates = 0;
+        restStates = 0;
+        keptStates = 0;
 
         int pass = (int) ChronoState.getState(world).getTickID();
 
@@ -293,12 +299,12 @@ public class Simulation {
 
             long iterationMs = System.currentTimeMillis() - startIterationMs;
             if (iterationMs > Config.ConfigDebug.physicsWarnThresholdMs) {
-                ImmersiveRailroading.warn("Calculating Immersive Railroading Physics Iteration took %sms (dirty: %s)", iterationMs, anyStartedDirty);
+                ImmersiveRailroading.warn("Calculating Immersive Railroading Physics Iteration took %sms (dirty: %s, %s, %s, %s)", iterationMs, anyStartedDirty, calculatedStates, restStates, keptStates);
             }
         }
         long totalMs = System.currentTimeMillis() - startMs;
         if (totalMs > Config.ConfigDebug.physicsWarnTotalThresholdMs) {
-            ImmersiveRailroading.warn("Calculating Immersive Railroading Physics took %sms : %sms (dirty: %s)", totalMs, System.currentTimeMillis() - startStatesMs, anyStartedDirty);
+            ImmersiveRailroading.warn("Calculating Immersive Railroading Physics took %sms : %sms (dirty: %s, %s, %s, %s)", totalMs, System.currentTimeMillis() - startStatesMs, anyStartedDirty, calculatedStates, restStates, keptStates);
         }
 
         boolean sendPackets = world.getTicks() % 20 == 0 || anyStartedDirty;

--- a/src/main/java/cam72cam/immersiverailroading/entity/physics/Simulation.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/physics/Simulation.java
@@ -82,9 +82,10 @@ public class Simulation {
         for (int tryLoad = 0; tryLoad < 10; tryLoad++) {
             // If this is too slow, we could hang onto the list of stock that is at rest.
             // We should only need to do this when stock is no longer at rest or changes dirty flag
+            int lastCount = loaded == null ? 0 : loaded.size();
             loaded = world.getEntities(EntityCoupleableRollingStock.class);
+            boolean newChunksLoaded = lastCount != loaded.size();
 
-            boolean newChunksLoaded = false;
             for (EntityCoupleableRollingStock stock : loaded) {
 
                 if (!stateMap.containsKey(stock.getUUID())) {

--- a/src/main/java/cam72cam/immersiverailroading/entity/physics/Simulation.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/physics/Simulation.java
@@ -32,6 +32,8 @@ public class Simulation {
 
 
     public Simulation(World world) {
+        calculatedStates = keptStates = restStates = 0;
+        long startTimeMs = System.currentTimeMillis();
         this.world = world;
         this.startTickID = ((ServerChronoState)ChronoState.getState(world)).getServerTickID();
 
@@ -61,9 +63,16 @@ public class Simulation {
                 new MRSSyncPacket(stock, stock.positions).sendToObserving(stock);
             }
         }
+
+        long totalTimeMs = System.currentTimeMillis() - startTimeMs;
+        if (totalTimeMs > Config.ConfigDebug.physicsWarnTotalThresholdMs) {
+            ImmersiveRailroading.warn("Calculating Immersive Railroading Physics took %sms (%s, %s, %s)", totalTimeMs, calculatedStates, restStates, keptStates);
+        }
     }
 
     public void simulateTick(int iteration) {
+        long startTimeMs = System.currentTimeMillis();
+
         int tickID = startTickID + iteration;
 
         Map<UUID, SimulationState> stateMap = stateMaps.get(iteration);
@@ -337,6 +346,11 @@ public class Simulation {
 
         // calculate new velocities
         Consist.iterate(stateMap, nextStateMap, blocksAlreadyBroken);
+
+        long totalTimeMs = System.currentTimeMillis() - startTimeMs;
+        if (totalTimeMs > Config.ConfigDebug.physicsWarnThresholdMs) {
+            ImmersiveRailroading.warn("Calculating Immersive Railroading Physics Iteration took %sms (%s, %s, %s)", totalTimeMs, calculatedStates, restStates, keptStates);
+        }
     }
 
 

--- a/src/main/java/cam72cam/immersiverailroading/entity/physics/Simulation.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/physics/Simulation.java
@@ -88,18 +88,19 @@ public class Simulation {
             for (EntityCoupleableRollingStock stock : loaded) {
 
                 if (!stateMap.containsKey(stock.getUUID())) {
-                    if (stock.states.isEmpty()) {
+                    for (SimulationState state : stock.states) {
+                        int stateIteration = state.tickID - tickID;
+                        if (stateIteration >= 0) {
+                            state.update(stock);
+                            stateMaps.get(stateIteration).put(stock.getUUID(), state);
+                        }
+                    }
+
+                    if (!stateMap.containsKey(stock.getUUID())) {
+                        // This should only ever happen right after stock is placed.
                         SimulationState state = new SimulationState(stock);
                         state.tickID = tickID;
                         stateMap.put(stock.getUUID(), state);
-                    } else {
-                        for (SimulationState state : stock.states) {
-                            int stateIteration = state.tickID - tickID;
-                            if (stateIteration >= 0) {
-                                state.update(stock);
-                                stateMaps.get(stateIteration).put(stock.getUUID(), state);
-                            }
-                        }
                     }
                 }
 

--- a/src/main/java/cam72cam/immersiverailroading/entity/physics/SimulationState.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/physics/SimulationState.java
@@ -67,7 +67,7 @@ public class SimulationState {
     public boolean frontPulling;
     public boolean rearPushing;
     public boolean rearPulling;
-    public List<UUID> consist;
+    public Consist consist;
 
     public static class Configuration {
         public UUID id;
@@ -201,7 +201,7 @@ public class SimulationState {
         calculateBlockCollisions(Collections.emptyList());
         blocksToBreak = Collections.emptyList();
 
-        consist = Collections.singletonList(config.id);
+        consist = stock.consist;
     }
 
     private SimulationState(SimulationState prev) {

--- a/src/main/java/cam72cam/immersiverailroading/entity/physics/SimulationState.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/physics/SimulationState.java
@@ -410,7 +410,7 @@ public class SimulationState {
     }
 
     public boolean atRest() {
-        return velocity == 0 && forcesNewtons() < frictionNewtons();
+        return velocity == 0 && Math.abs(forcesNewtons()) < frictionNewtons();
     }
 
     public double frictionNewtons() {

--- a/src/main/java/cam72cam/immersiverailroading/entity/physics/SimulationState.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/physics/SimulationState.java
@@ -203,10 +203,8 @@ public class SimulationState {
 
         consist = stock.consist;
 
-        if (stock.getTickCount() <= 5) {
-            // Just loaded, not dirty yet
-            dirty = false;
-        }
+        // If we just placed it, need to adjust it.  Otherwise, it already existed and is just loading in
+        dirty = stock.newlyPlaced;
     }
 
     private SimulationState(SimulationState prev) {

--- a/src/main/java/cam72cam/immersiverailroading/tile/TileRailBase.java
+++ b/src/main/java/cam72cam/immersiverailroading/tile/TileRailBase.java
@@ -359,6 +359,7 @@ public class TileRailBase extends BlockEntityTrackTickable implements IRedstoneP
 		return getNextPositionShort(currentPosition, motion);
 	}
 
+	private Collection<TileRail> tiles = null;
 	public Vec3d getNextPositionShort(Vec3d currentPosition, Vec3d motion) {
 		if (this.getReplaced() == null) {
 			// Simple common case, maybe this does not need to be optimized out of the for loop below?
@@ -383,20 +384,22 @@ public class TileRailBase extends BlockEntityTrackTickable implements IRedstoneP
 			return currentPosition;
 		}
 		// Complex case with overlapping segments
-		Map<Vec3i, TileRail> tileMap = new HashMap<>();
-		for (TileRailBase current = this; current != null; current = current.getReplacedTile()) {
-			TileRail tile = current instanceof TileRail ? (TileRail) current : current.getParentTile();
-			TileRail parent = tile;
-			while (parent != null && !parent.getPos().equals(parent.getParent())) {
-				// Move to root of switch (if applicable)
-				parent = parent.getParentTile();
+		if (tiles == null) {
+			Map<Vec3i, TileRail> tileMap = new HashMap<>();
+			for (TileRailBase current = this; current != null; current = current.getReplacedTile()) {
+				TileRail tile = current instanceof TileRail ? (TileRail) current : current.getParentTile();
+				TileRail parent = tile;
+				while (parent != null && !parent.getPos().equals(parent.getParent())) {
+					// Move to root of switch (if applicable)
+					parent = parent.getParentTile();
+				}
+				if (tile != null && parent != null) {
+					tileMap.putIfAbsent(parent.getPos(), tile);
+				}
 			}
-			if (tile != null && parent != null) {
-				tileMap.putIfAbsent(parent.getPos(), tile);
-			}
+			tiles = tileMap.values();
 		}
 
-		Collection<TileRail> tiles = tileMap.values();
 
 		Vec3d nextPos = currentPosition;
 		Vec3d predictedPos = currentPosition.add(motion);

--- a/src/main/java/cam72cam/immersiverailroading/track/IIterableTrack.java
+++ b/src/main/java/cam72cam/immersiverailroading/track/IIterableTrack.java
@@ -12,17 +12,39 @@ public interface IIterableTrack {
     List<BuilderBase> getSubBuilders();
 
     default double offsetFromTrack(RailInfo info, Vec3i pos, Vec3d position) {
-        double distSquared = 100 * 100;
 
         // Convert to relative
-        position = position.subtract(info.placementInfo.placementPosition).subtract(pos);
+        Vec3d relative = position.subtract(info.placementInfo.placementPosition).subtract(pos);
+        relative = relative.add(0, -(relative.y % 1), 0);
 
-        for (Vec3d gagPos : getPath(info.settings.gauge.scale()/8)) {
-            double offSquared = gagPos.distanceToSquared(position.add(0, -(position.y % 1), 0));
+        List<PosStep> positions = getPath(info.settings.gauge.scale() / 8);
+
+        /*
+        double distSquared = 100 * 100;
+        for (Vec3d gagPos : positions) {
+            double offSquared = gagPos.distanceToSquared(relative);
             if (offSquared < distSquared) {
                 distSquared = offSquared;
             }
         }
         return Math.sqrt(distSquared);
+        */
+
+        int left = 0;
+        double leftDistance = positions.get(left).distanceToSquared(relative);
+        int right = positions.size() - 1;
+        double rightDistance = positions.get(right).distanceToSquared(relative);
+        while (right - left > 1) {
+            double midIdx = left + (right - left) / 2f;
+
+            if (leftDistance > rightDistance) {
+                left = (int) Math.floor(midIdx);
+                leftDistance = positions.get(left).distanceToSquared(relative);
+            } else {
+                right = (int) Math.ceil(midIdx);
+                rightDistance = positions.get(right).distanceToSquared(relative);
+            }
+        }
+        return Math.sqrt(Math.min(rightDistance, leftDistance));
     }
 }

--- a/src/main/java/cam72cam/immersiverailroading/util/SpawnUtil.java
+++ b/src/main/java/cam72cam/immersiverailroading/util/SpawnUtil.java
@@ -78,6 +78,8 @@ public class SpawnUtil {
 						moveable.setRearYaw(VecUtil.toWrongYaw(rearNext.subtract(rear)));
 					}
 				}
+
+				moveable.newlyPlaced = true;
 			}
 
 			if (stock instanceof EntityBuildableRollingStock) {

--- a/src/main/java/cam72cam/immersiverailroading/util/SpawnUtil.java
+++ b/src/main/java/cam72cam/immersiverailroading/util/SpawnUtil.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.List;
 
 import cam72cam.immersiverailroading.entity.EntityCoupleableRollingStock;
+import cam72cam.immersiverailroading.entity.EntityMoveableRollingStock;
 import cam72cam.immersiverailroading.entity.EntityRollingStock;
 import cam72cam.immersiverailroading.entity.physics.SimulationState;
 import cam72cam.immersiverailroading.items.ItemRollingStock;
@@ -46,21 +47,35 @@ public class SpawnUtil {
 		if (worldIn.isServer) {
 			EntityRollingStock stock = def.spawn(worldIn, new Vec3d(pos).add(0.5, 0.1, 0.5), yaw, gauge, data.texture);
 
-			if (stock instanceof EntityCoupleableRollingStock) {
-				EntityCoupleableRollingStock ecrs = (EntityCoupleableRollingStock) stock;
-				outer:
-				for (int i = 0; i <= 90; i+= 5) {
-					for (int j = -1; j <= 1; j += 2) {
-						ecrs.setRotationYaw(yaw + i * j);
-						SimulationState state = new SimulationState(ecrs).next(offset, new ArrayList<>());
-						if (state.position.distanceTo(ecrs.getPosition()) > offset/2) {
-							ecrs.setPosition(state.position);
-							ecrs.setRotationYaw(state.yaw);
-							ecrs.setRotationPitch(state.pitch);
-							ecrs.setFrontYaw(state.yawFront);
-							ecrs.setRearYaw(state.yawRear);
-							break outer;
-						}
+			Vec3d center = stock.getPosition();
+			center = initte.getNextPosition(center, VecUtil.fromWrongYaw(-0.1, yaw));
+			center = initte.getNextPosition(center, VecUtil.fromWrongYaw(0.1, yaw));
+			center = initte.getNextPosition(center, VecUtil.fromWrongYaw(offset, yaw));
+			stock.setPosition(center);
+
+			if (stock instanceof EntityMoveableRollingStock) {
+				EntityMoveableRollingStock moveable = (EntityMoveableRollingStock)stock;
+				ITrack centerte = ITrack.get(worldIn, center, true);
+				if (centerte != null) {
+					float frontDistance = moveable.getDefinition().getBogeyFront(gauge);
+					float rearDistance = moveable.getDefinition().getBogeyRear(gauge);
+					Vec3d front = centerte.getNextPosition(center, VecUtil.fromWrongYaw(frontDistance, yaw));
+					Vec3d rear = centerte.getNextPosition(center, VecUtil.fromWrongYaw(rearDistance, yaw));
+
+					moveable.setRotationYaw(VecUtil.toWrongYaw(front.subtract(rear)));
+					moveable.setRotationPitch(VecUtil.toPitch(front.subtract(rear)) - 90);
+					moveable.setPosition(rear.add(front.subtract(rear).scale(frontDistance / (frontDistance - rearDistance))));
+
+					ITrack frontte = ITrack.get(worldIn, front, true);
+					if (frontte != null) {
+						Vec3d frontNext = frontte.getNextPosition(front, VecUtil.fromWrongYaw(0.1 * gauge.scale(), moveable.getRotationYaw()));
+						moveable.setFrontYaw(VecUtil.toWrongYaw(frontNext.subtract(front)));
+					}
+
+					ITrack rearte = ITrack.get(worldIn, rear, true);
+					if (rearte != null) {
+						Vec3d rearNext = rearte.getNextPosition(rear, VecUtil.fromWrongYaw(0.1 * gauge.scale(), moveable.getRotationYaw()));
+						moveable.setRearYaw(VecUtil.toWrongYaw(rearNext.subtract(rear)));
 					}
 				}
 			}


### PR DESCRIPTION
There are a few pieces to this:
* Tracking consists for chunk loading / dirty flag propagation
* Faster track pathing
* Chunk loading management pre each physics tick calculation.
* Better train placement logic

The most drastic change is that the keepStockLoaded flag should not be critical or even needed to prevent stopped trains from decoupling due to chunk loading issues.