### PR TITLE
Make left-first crank pin an adjustable feature

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,4 +37,3 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: Immersive Railroading ${{matrix.branch}}
-        path: build/libs/ImmersiveRailroading-${{matrix.branch}}*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,3 +37,4 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: Immersive Railroading ${{matrix.branch}}
+        path: build/libs/ImmersiveRailroading-${{matrix.branch}}*

--- a/src/main/java/cam72cam/immersiverailroading/model/LocomotiveModel.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/LocomotiveModel.java
@@ -116,7 +116,7 @@ public class LocomotiveModel<ENTITY extends Locomotive, DEFINITION extends Locom
         frontLocomotiveRocking.include(shellFront);
 
         cargoFillFront = CargoFill.get(provider, frontLocomotiveRocking, showCurrentLoadOnly, ModelPosition.FRONT);
-        drivingWheelsFront = DrivingAssembly.get(type, provider, frontLocomotive, ModelPosition.FRONT, 0);
+        drivingWheelsFront = DrivingAssembly.get(type, provider, frontLocomotive, ModelPosition.FRONT, 0,  def.isLeftFirst);
 
 
         frameRear = provider.parse(ModelComponentType.REAR_FRAME);
@@ -125,7 +125,7 @@ public class LocomotiveModel<ENTITY extends Locomotive, DEFINITION extends Locom
         rearLocomotiveRocking.include(shellRear);
 
         cargoFillRear = CargoFill.get(provider, rearLocomotiveRocking, showCurrentLoadOnly, ModelPosition.REAR);
-        drivingWheelsRear = DrivingAssembly.get(type, provider, rearLocomotive, ModelPosition.REAR, 45);
+        drivingWheelsRear = DrivingAssembly.get(type, provider, rearLocomotive, ModelPosition.REAR, 45,  def.isLeftFirst);
 
         components = provider.parse(
                 new ModelComponentType[]{ModelComponentType.CAB}

--- a/src/main/java/cam72cam/immersiverailroading/model/StockModel.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/StockModel.java
@@ -221,7 +221,7 @@ public class StockModel<ENTITY extends EntityMoveableRollingStock, DEFINITION ex
     protected void parseComponents(ComponentProvider provider, DEFINITION def) {
         this.frame = new Frame(provider, base, rocking, def.defID);
 
-        drivingWheels = DrivingAssembly.get(def.getValveGear(), provider, base, 0,
+        drivingWheels = DrivingAssembly.get(def.getValveGear(), provider, base, 0, def.isLeftFirst,
                 frame != null ? frame.wheels : null,
                 bogeyFront != null ? bogeyFront.wheels : null,
                 bogeyRear != null ? bogeyRear.wheels : null

--- a/src/main/java/cam72cam/immersiverailroading/model/part/DrivingAssembly.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/DrivingAssembly.java
@@ -39,25 +39,14 @@ public class DrivingAssembly {
             return null;
         }
 
-        ValveGear left,
-                inner_left,
-                center,
-                inner_right,
-                right;
+        int angleDirection = isLeftFirst ? 1 : -1;
 
-        if(isLeftFirst) {
-            left = ValveGear.get(wheels, type, provider, state, ModelPosition.LEFT.and(pos), 0);
-            inner_left = ValveGear.get(wheels, type, provider, state, ModelPosition.INNER_LEFT.and(pos), 180);
-            center = ValveGear.get(wheels, type, provider, state, ModelPosition.CENTER.and(pos), -120);
-            inner_right = ValveGear.get(wheels, type, provider, state, ModelPosition.INNER_RIGHT.and(pos), 90);
-            right = ValveGear.get(wheels, type, provider, state, ModelPosition.RIGHT.and(pos), center == null ? -90 : -240);
-        }else {
-            left = ValveGear.get(wheels, type, provider, state, ModelPosition.LEFT.and(pos), 0);
-            inner_left = ValveGear.get(wheels, type, provider, state, ModelPosition.INNER_LEFT.and(pos), -180);
-            center = ValveGear.get(wheels, type, provider, state, ModelPosition.CENTER.and(pos), 120);
-            inner_right = ValveGear.get(wheels, type, provider, state, ModelPosition.INNER_RIGHT.and(pos), -90);
-            right = ValveGear.get(wheels, type, provider, state, ModelPosition.RIGHT.and(pos), center == null ? 90 : 240);
-        }
+        ValveGear left = ValveGear.get(wheels, type, provider, state, ModelPosition.LEFT.and(pos), 0);
+        ValveGear inner_left = ValveGear.get(wheels, type, provider, state, ModelPosition.INNER_LEFT.and(pos), angleDirection * (180));
+        ValveGear center = ValveGear.get(wheels, type, provider, state, ModelPosition.CENTER.and(pos), angleDirection * (-120));
+        ValveGear inner_right = ValveGear.get(wheels, type, provider, state, ModelPosition.INNER_RIGHT.and(pos), angleDirection * (90));
+        ValveGear right = ValveGear.get(wheels, type, provider, state, ModelPosition.RIGHT.and(pos), angleDirection * (center == null ? -90 : -240));
+
         ModelComponent steamChest = pos == null ?
                 provider.parse(ModelComponentType.STEAM_CHEST) :
                 provider.parse(ModelComponentType.STEAM_CHEST_POS, pos);

--- a/src/main/java/cam72cam/immersiverailroading/model/part/DrivingAssembly.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/DrivingAssembly.java
@@ -42,9 +42,9 @@ public class DrivingAssembly {
         int angleDirection = isLeftFirst ? 1 : -1;
 
         ValveGear left = ValveGear.get(wheels, type, provider, state, ModelPosition.LEFT.and(pos), 0);
-        ValveGear inner_left = ValveGear.get(wheels, type, provider, state, ModelPosition.INNER_LEFT.and(pos), angleDirection * (180));
-        ValveGear center = ValveGear.get(wheels, type, provider, state, ModelPosition.CENTER.and(pos), angleDirection * (-120));
-        ValveGear inner_right = ValveGear.get(wheels, type, provider, state, ModelPosition.INNER_RIGHT.and(pos), angleDirection * (90));
+        ValveGear inner_left = ValveGear.get(wheels, type, provider, state, ModelPosition.INNER_LEFT.and(pos), angleDirection * 180);
+        ValveGear center = ValveGear.get(wheels, type, provider, state, ModelPosition.CENTER.and(pos), angleDirection * -120);
+        ValveGear inner_right = ValveGear.get(wheels, type, provider, state, ModelPosition.INNER_RIGHT.and(pos), angleDirection * 90);
         ValveGear right = ValveGear.get(wheels, type, provider, state, ModelPosition.RIGHT.and(pos), angleDirection * (center == null ? -90 : -240));
 
         ModelComponent steamChest = pos == null ?

--- a/src/main/java/cam72cam/immersiverailroading/model/part/DrivingAssembly.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/DrivingAssembly.java
@@ -17,11 +17,15 @@ public class DrivingAssembly {
     private final ValveGear left;
     private final ModelComponent steamChest;
 
-    public static DrivingAssembly get(ValveGearConfig type, ComponentProvider provider, ModelState state, float angleOffset, WheelSet... backups) {
-        return get(type, provider, state, null, angleOffset, backups);
+    public static DrivingAssembly get(ValveGearConfig type, ComponentProvider provider, ModelState state, float angleOffset, boolean isLeftFirst, WheelSet... backups) {
+        return get(type, provider, state, null, angleOffset, isLeftFirst, backups);
     }
 
-    public static DrivingAssembly get(ValveGearConfig type, ComponentProvider provider, ModelState state, ModelPosition pos, float angleOffset, WheelSet... backups) {
+    public static DrivingAssembly get(ValveGearConfig type, ComponentProvider provider, ModelState state, float angleOffset, WheelSet... backups) {
+        return get(type, provider, state, null, angleOffset, true, backups);
+    }
+
+    public static DrivingAssembly get(ValveGearConfig type, ComponentProvider provider, ModelState state, ModelPosition pos, float angleOffset, boolean isLeftFirst, WheelSet... backups) {
         WheelSet wheels = WheelSet.get(provider, state, pos == null ? ModelComponentType.WHEEL_DRIVER_X : ModelComponentType.WHEEL_DRIVER_POS_X, pos, angleOffset);
         if (wheels == null) {
             for (WheelSet backup : backups) {
@@ -35,12 +39,25 @@ public class DrivingAssembly {
             return null;
         }
 
-        ValveGear left = ValveGear.get(wheels, type, provider, state, ModelPosition.LEFT.and(pos), 0);
-        ValveGear inner_left = ValveGear.get(wheels, type, provider, state, ModelPosition.INNER_LEFT.and(pos), 180);
-        ValveGear center = ValveGear.get(wheels, type, provider, state, ModelPosition.CENTER.and(pos), -120);
-        ValveGear inner_right = ValveGear.get(wheels, type, provider, state, ModelPosition.INNER_RIGHT.and(pos), 90);
-        ValveGear right = ValveGear.get(wheels, type, provider, state, ModelPosition.RIGHT.and(pos), center == null ? -90 : -240);
+        ValveGear left,
+                inner_left,
+                center,
+                inner_right,
+                right;
 
+        if(isLeftFirst) {
+            left = ValveGear.get(wheels, type, provider, state, ModelPosition.LEFT.and(pos), 0);
+            inner_left = ValveGear.get(wheels, type, provider, state, ModelPosition.INNER_LEFT.and(pos), 180);
+            center = ValveGear.get(wheels, type, provider, state, ModelPosition.CENTER.and(pos), -120);
+            inner_right = ValveGear.get(wheels, type, provider, state, ModelPosition.INNER_RIGHT.and(pos), 90);
+            right = ValveGear.get(wheels, type, provider, state, ModelPosition.RIGHT.and(pos), center == null ? -90 : -240);
+        }else {
+            left = ValveGear.get(wheels, type, provider, state, ModelPosition.LEFT.and(pos), 0);
+            inner_left = ValveGear.get(wheels, type, provider, state, ModelPosition.INNER_LEFT.and(pos), -180);
+            center = ValveGear.get(wheels, type, provider, state, ModelPosition.CENTER.and(pos), 120);
+            inner_right = ValveGear.get(wheels, type, provider, state, ModelPosition.INNER_RIGHT.and(pos), -90);
+            right = ValveGear.get(wheels, type, provider, state, ModelPosition.RIGHT.and(pos), center == null ? 90 : 240);
+        }
         ModelComponent steamChest = pos == null ?
                 provider.parse(ModelComponentType.STEAM_CHEST) :
                 provider.parse(ModelComponentType.STEAM_CHEST_POS, pos);

--- a/src/main/java/cam72cam/immersiverailroading/registry/EntityRollingStockDefinition.java
+++ b/src/main/java/cam72cam/immersiverailroading/registry/EntityRollingStockDefinition.java
@@ -472,7 +472,7 @@ public abstract class EntityRollingStockDefinition {
         weight = properties.getValue("weight_kg").asInteger() * internal_inv_scale;
         valveGear = ValveGearConfig.get(properties, "valve_gear");
         if(valveGear !=  null){
-            isLeftFirst = properties.getValue("left_first").asBoolean(true);
+            isLeftFirst = properties.getValue("left_first").asBoolean();
         }
         hasIndependentBrake = properties.getValue("independent_brake").asBoolean();
         hasPressureBrake = properties.getValue("pressure_brake").asBoolean();

--- a/src/main/java/cam72cam/immersiverailroading/registry/EntityRollingStockDefinition.java
+++ b/src/main/java/cam72cam/immersiverailroading/registry/EntityRollingStockDefinition.java
@@ -64,6 +64,7 @@ public abstract class EntityRollingStockDefinition {
     private String modelerName;
     private String packName;
     private ValveGearConfig valveGear;
+    public boolean isLeftFirst;
     public float darken;
     public Identifier modelLoc;
     protected StockModel<?, ?> model;
@@ -470,6 +471,9 @@ public abstract class EntityRollingStockDefinition {
         DataBlock properties = data.getBlock("properties");
         weight = properties.getValue("weight_kg").asInteger() * internal_inv_scale;
         valveGear = ValveGearConfig.get(properties, "valve_gear");
+        if(valveGear !=  null){
+            isLeftFirst = properties.getValue("left_first").asBoolean(true);
+        }
         hasIndependentBrake = properties.getValue("independent_brake").asBoolean();
         hasPressureBrake = properties.getValue("pressure_brake").asBoolean();
         // Locomotives default to linear brake control

--- a/src/main/resources/assets/immersiverailroading/rolling_stock/default/base.caml
+++ b/src/main/resources/assets/immersiverailroading/rolling_stock/default/base.caml
@@ -48,6 +48,7 @@ properties =                # Required:
 #       -1.0 = immersiverailroading:some/path/animation_-1.0.anim # Reverse
 #       0.0 = immersiverailroading:some/path/animation_0.0.anim # Neutral
 #       1.0 = immersiverailroading:some/path/animation_1.0.anim # Forward
+#   left_first = true            # Optional: Should this valve gear be at left-first crank pin position? Default is true
 
     independent_brake = False           # Optional: Does this piece of stock have an independent brake?  Usually False except for Locomotives
     pressure_brake = True               # Optional: Does this piece of stock have a pressure brake?  Usually True except for Hand Cars

--- a/src/main/resources/assets/immersiverailroading/rolling_stock/default/base.caml
+++ b/src/main/resources/assets/immersiverailroading/rolling_stock/default/base.caml
@@ -48,7 +48,7 @@ properties =                # Required:
 #       -1.0 = immersiverailroading:some/path/animation_-1.0.anim # Reverse
 #       0.0 = immersiverailroading:some/path/animation_0.0.anim # Neutral
 #       1.0 = immersiverailroading:some/path/animation_1.0.anim # Forward
-   left_first = true            # Required if valve_gear is defined: Should this valve gear be at left-first crank pin position? Set false to make it right-first
+    left_first = true            # Required if valve_gear is defined: Should this valve gear be at left-first crank pin position? Set false to make it right-first
 
     independent_brake = False           # Optional: Does this piece of stock have an independent brake?  Usually False except for Locomotives
     pressure_brake = True               # Optional: Does this piece of stock have a pressure brake?  Usually True except for Hand Cars

--- a/src/main/resources/assets/immersiverailroading/rolling_stock/default/base.caml
+++ b/src/main/resources/assets/immersiverailroading/rolling_stock/default/base.caml
@@ -48,7 +48,7 @@ properties =                # Required:
 #       -1.0 = immersiverailroading:some/path/animation_-1.0.anim # Reverse
 #       0.0 = immersiverailroading:some/path/animation_0.0.anim # Neutral
 #       1.0 = immersiverailroading:some/path/animation_1.0.anim # Forward
-#   left_first = true            # Optional: Should this valve gear be at left-first crank pin position? Default is true
+   left_first = true            # Required if valve_gear is defined: Should this valve gear be at left-first crank pin position? Set false to make it right-first
 
     independent_brake = False           # Optional: Does this piece of stock have an independent brake?  Usually False except for Locomotives
     pressure_brake = True               # Optional: Does this piece of stock have a pressure brake?  Usually True except for Hand Cars


### PR DESCRIPTION
In the past IR makes valve gears to be at left-first crank pin position by default,while many stocks are right-first.
These code adds "left_first" for stocks to change the crank pin's default position.