### PR TITLE
Allow Track Tiles to Build in Snow

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/track/BuilderBase.java
+++ b/src/main/java/cam72cam/immersiverailroading/track/BuilderBase.java
@@ -154,11 +154,11 @@ public abstract class BuilderBase {
 		this.drops = drops;
 	}
 
-	public void clearArea() {
+	public void clearArea() { // Clear 6-block tall right-of-way ignoring snow UNLESS the snow directly intersects with the location of a future track tile.
 		for (TrackBase track : tracks) {
 			for (int i = 0; i < 6 * info.settings.gauge.scale(); i++) {
 				Vec3i main = track.getPos().up(i);
-				if (!ITrack.isRail(world, main) && !world.isSnow(main)) {
+				if (!ITrack.isRail(world, main) && (i == 0 || !world.isSnow(main))) {
 					world.setToAir(main);
 				}
 				if (info.settings.gauge.isModel() && ConfigDamage.enableSideBlockClearing && info.settings.type != TrackItems.SLOPE && info.settings.type != TrackItems.TURNTABLE) {


### PR DESCRIPTION
Made exception to allow break-block placement to clear snow from the specific tiles where the rails are to be built. This solves the existing issue that made creative track building through snowy areas tedious and required manual snow harvesting. Note: This doesn't change any prerequisites for requireSolid.