### PR TITLE
Fixed Grade Crossing Math

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/track/BuilderIterator.java
+++ b/src/main/java/cam72cam/immersiverailroading/track/BuilderIterator.java
@@ -75,7 +75,7 @@ public abstract class BuilderIterator extends BuilderBase implements IIterableTr
 				int posZ = (int)Math.floor(gagPos.z+nextUp.z+placeOff.z);
 				double height = 0;
 				if (info.settings.isGradeCrossing) {
-					height = (1 - Math.abs((int)q)/horiz)/3 - 0.05;
+					height = 0.306 - Math.abs(Math.round(q))/(3 * horiz);
 					height *= info.settings.gauge.scale();
 					height = Math.min(height, clamp);
 				}


### PR DESCRIPTION
Manipulated terms in Grade crossing math to reduce chained operations. Symmetrized behavior for positive and negative values of q to make grade crossing heights symmetrical on both sides of track.
![2024-04-14_01 48 13](https://github.com/TeamOpenIndustry/ImmersiveRailroading/assets/19310181/82023358-15ca-4f79-89cf-c9824615ce33)
