### PR TITLE
Chore: update GH actions script to v4

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -1,6 +1,6 @@
 name: Immersive Railroading Build Pipeline
 
-on: 
+on:
   push:
     branches-ignore:
       - 'master'
@@ -12,11 +12,12 @@ jobs:
       matrix:
         branch: [1.12.2-forge, 1.16.5-forge]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
-        java-version: 1.8
+        java-version: '8'
+        distribution: 'temurin'
     - name: keyscan
       run: mkdir -p ~/.ssh/ && ssh-keyscan -t rsa teamopenindustry.cc >> ~/.ssh/known_hosts
     - name: Install deps
@@ -37,7 +38,7 @@ jobs:
       env:
         MAVENCI_PASS: ${{ secrets.MAVENCI_PASS }}
       run: ./gradlew publish
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: Immersive Railroading ${{matrix.branch}}
         path: build/libs/ImmersiveRailroading-${{matrix.branch}}-*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,12 @@ jobs:
       matrix:
         branch: [1.7.10-forge, 1.10.2-forge, 1.11.2-forge, 1.12.2-forge, 1.14.4-forge, 1.15.2-forge, 1.16.5-forge, 1.17.1-forge, 1.18.2-forge, 1.19.4-forge, 1.20.1-forge]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
-        java-version: 1.8
+        java-version: '8'
+        distribution: 'temurin'
     - name: keyscan
       run: mkdir -p ~/.ssh/ && ssh-keyscan -t rsa teamopenindustry.cc >> ~/.ssh/known_hosts
     - name: Install deps
@@ -37,7 +38,7 @@ jobs:
       env:
         MAVENCI_PASS: ${{ secrets.MAVENCI_PASS }}
       run: ./gradlew publish
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: Immersive Railroading ${{matrix.branch}}
         path: build/libs/ImmersiveRailroading-${{matrix.branch}}-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,12 @@ jobs:
       matrix:
         branch: [1.7.10-forge, 1.10.2-forge, 1.11.2-forge, 1.12.2-forge, 1.14.4-forge, 1.15.2-forge, 1.16.5-forge]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
-        java-version: 1.8
+        java-version: '8'
+        distribution: 'temurin'
     - name: keyscan
       run: mkdir -p ~/.ssh/ && ssh-keyscan -t rsa teamopenindustry.cc >> ~/.ssh/known_hosts
     - name: Install deps
@@ -34,7 +35,7 @@ jobs:
       env:
         MAVENCI_PASS: ${{ secrets.MAVENCI_PASS }}
       run: ./gradlew publish -Dtarget=release
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: Immersive Railroading ${{matrix.branch}}
         path: build/libs/ImmersiveRailroading-${{matrix.branch}}*


### PR DESCRIPTION
With the deprecation of v1&v2 workflow at the beginning of 2024, IR's build pipeline had been exist in name only since it used v2.
This PR aims to migrate the build pipeline to modern versions of GH actions in order to recover its function.