### PR TITLE
Fix: Un-built stock can be controlled by dragging

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/entity/ClientPartDragging.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/ClientPartDragging.java
@@ -180,6 +180,10 @@ public class ClientPartDragging {
             Double min = null;
 
             for (EntityRollingStock stock : world.getEntities(EntityRollingStock.class)) {
+                if(stock instanceof EntityBuildableRollingStock && !((EntityBuildableRollingStock) stock).isBuilt()){
+                    continue;
+                }
+
                 if (stock.getPosition().distanceToSquared(player.getPosition()) > stock.getDefinition().getLength(stock.gauge) * stock.getDefinition().getLength(stock.gauge)) {
                     continue;
                 }


### PR DESCRIPTION
IR doesn't check stock's building status when processing control drag, so users can control an unfinished stock. This this pr fixes that.