### PR TITLE
Changes in Golden Spike

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/items/ItemGoldenSpike.java
+++ b/src/main/java/cam72cam/immersiverailroading/items/ItemGoldenSpike.java
@@ -63,7 +63,15 @@ public class ItemGoldenSpike extends CustomItem {
 					if (tr.isAboveRails()) {
 						tepos = tepos.down();
 					}
-					tr.setCustomInfo(new PlacementInfo(tr.getItem(), player.getYawHead(), hit.subtract(0, hit.y, 0).add(pos).subtract(tepos)));
+					//If x or z < 0 there are some weird things...
+					Vec3d finalPos = hit.subtract(0, hit.y, 0).add(pos).subtract(tepos);
+					if(finalPos.x < 0){
+						finalPos = finalPos.add(1,0,0);
+					}
+					if(finalPos.z < 0){
+						finalPos = finalPos.add(0,0,1);
+					}
+					tr.setCustomInfo(new PlacementInfo(tr.getItem(), player.getYawHead(), finalPos));
 				}
 			}
 		}

--- a/src/main/java/cam72cam/immersiverailroading/tile/TileRailPreview.java
+++ b/src/main/java/cam72cam/immersiverailroading/tile/TileRailPreview.java
@@ -69,45 +69,45 @@ public class TileRailPreview extends BlockEntityTickable {
 		info = null;
 	}
 
-	public void setCustomInfo(PlacementInfo info) {
-		this.customInfo = info;
-		if (customInfo != null) {
-			RailSettings settings = RailSettings.from(item);
-			float yaw = settings.type == TrackItems.TURN ? placementInfo.yaw / 2 : placementInfo.yaw;
-			if(settings.type ==TrackItems.TURN
-					|| settings.type == TrackItems.STRAIGHT
-					|| settings.type == TrackItems.SLOPE){
-				Vec3d placeOffset = new Vec3d(
-						customInfo.placementPosition.x - placementInfo.placementPosition.x,
-						0,
-						customInfo.placementPosition.z - placementInfo.placementPosition.z
-				);
-				Vec3d unit = new Vec3d(0, 0, 1).rotateYaw(yaw);
-				int shadowLength = (int) Math.round(VecUtil.dotMultiply(placeOffset, unit));
-				int length;
+    public void setCustomInfo(PlacementInfo info) {
+        this.customInfo = info;
+        if (customInfo != null) {
+            RailSettings settings = RailSettings.from(item);
+            float yaw = settings.type == TrackItems.TURN ? placementInfo.yaw / 2 : placementInfo.yaw;
+            if(settings.type ==TrackItems.TURN
+                    || settings.type == TrackItems.STRAIGHT
+                    || settings.type == TrackItems.SLOPE){
+                Vec3d placeOffset = new Vec3d(
+                        customInfo.placementPosition.x - placementInfo.placementPosition.x,
+                        0,
+                        customInfo.placementPosition.z - placementInfo.placementPosition.z
+                );
+                Vec3d unit = new Vec3d(0, 0, 1).rotateYaw(yaw);
+                int shadowLength = (int) Math.round(VecUtil.dotMultiply(placeOffset, unit));
+                int length;
 
-				switch (settings.type) {
-					case TURN:
-						double sin = Math.sin(Math.toRadians(settings.degrees / 2));
-						length = sin != 0d
-								 ? Math.max(0, (int) ((shadowLength / 2d) / sin)) + 1
-								 : 1;
-						break;
-					case STRAIGHT:
-					case SLOPE:
-					default:
-						length = Math.max(0, shadowLength) + 1;
-						break;
-				}
-				settings = settings.with(b -> b.length = length);
-			}
+                switch (settings.type) {
+                    case TURN:
+                        double sin = Math.sin(Math.toRadians(settings.degrees / 2));
+                        length = sin != 0d
+                                 ? Math.max(0, (int) ((shadowLength / 2d) / sin)) + 1
+                                 : 1;
+                        break;
+                    case STRAIGHT:
+                    case SLOPE:
+                    default:
+                        length = Math.max(0, shadowLength) + 1;
+                        break;
+                }
+                settings = settings.with(b -> b.length = length);
+            }
 
-			settings.write(item);
-		}
-		this.markDirty();
-	}
-	
-	public void setPlacementInfo(PlacementInfo info) {
+            settings.write(item);
+        }
+        this.markDirty();
+    }
+    
+    public void setPlacementInfo(PlacementInfo info) {
 		this.placementInfo = info;
 		this.markDirty();
 	}

--- a/src/main/java/cam72cam/immersiverailroading/util/VecUtil.java
+++ b/src/main/java/cam72cam/immersiverailroading/util/VecUtil.java
@@ -61,4 +61,8 @@ public class VecUtil {
 	public static Vec3d between(Vec3d front, Vec3d rear) {
 		return new Vec3d((front.x + rear.x) / 2, (front.y + rear.y) / 2, (front.z + rear.z) / 2);
 	}
+
+	public static double dotMultiply(Vec3d a, Vec3d b){
+		return a.x * b.x + a.y * b.y + a.z * b.z;
+	}
 }


### PR DESCRIPTION
1. Make Golden Spike on Straight/Slope/Turn set their length based on the projection length instead of directly use x/z difference
2. Fix a bug that custom curve have a wrong offset when spikePos.x < blueprintPos.x or spikePos.z < blueprintPos.z(Video at [bug-report](https://discord.com/channels/355731184157720578/356568200785166346/1190780765584244806))