### PR TITLE
feat: configuration for track max render distance

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/ConfigGraphics.java
+++ b/src/main/java/cam72cam/immersiverailroading/ConfigGraphics.java
@@ -3,7 +3,6 @@ package cam72cam.immersiverailroading;
 import cam72cam.immersiverailroading.library.PressureDisplayType;
 import cam72cam.immersiverailroading.library.SpeedDisplayType;
 import cam72cam.immersiverailroading.library.TemperatureDisplayType;
-import cam72cam.immersiverailroading.library.ValveGearConfig;
 import cam72cam.mod.config.ConfigFile.Comment;
 import cam72cam.mod.config.ConfigFile.Name;
 import cam72cam.mod.render.OptiFine;
@@ -68,4 +67,8 @@ public class ConfigGraphics {
 
 	@Comment("Try to fake interior lighting for locomotives/passenger cars that are being ridden")
 	public static boolean FakeInteriorLighting = true;
+
+	@Comment("The track's maximum visibility range")
+	@Range(min = 256, max = 4096)
+	public static double TrackRenderDistance = 256;
 }

--- a/src/main/java/cam72cam/immersiverailroading/tile/TileRail.java
+++ b/src/main/java/cam72cam/immersiverailroading/tile/TileRail.java
@@ -1,6 +1,7 @@
 package cam72cam.immersiverailroading.tile;
 
 import cam72cam.immersiverailroading.Config;
+import cam72cam.immersiverailroading.ConfigGraphics;
 import cam72cam.immersiverailroading.IRBlocks;
 import cam72cam.immersiverailroading.entity.EntityCoupleableRollingStock;
 import cam72cam.immersiverailroading.entity.physics.Simulation;
@@ -49,7 +50,7 @@ public class TileRail extends TileRailBase {
 	
 	@Override
 	public double getRenderDistance() {
-		return 8*32;
+		return ConfigGraphics.TrackRenderDistance;
 	}
 
 	public void setSwitchState(SwitchState state) {


### PR DESCRIPTION
Add config in ConfigGraphics for track's max render distance instead of hard-coded