### PR TITLE
Fix: TrackGUI element overlapping

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/gui/TrackGui.java
+++ b/src/main/java/cam72cam/immersiverailroading/gui/TrackGui.java
@@ -218,7 +218,7 @@ public class TrackGui implements IScreen {
 		//height = 20;
 		//xtop = GUIHelpers.getScreenWidth() / 2 - width;
 		//ytop = -GUIHelpers.getScreenHeight() / 4;
-		ytop = (int) (GUIHelpers.getScreenHeight() * 0.75 - height * 6);
+		ytop = (int) (GUIHelpers.getScreenHeight() * 0.75 - height * 5);
 
 		trackSelector = new ListSelector<TrackDefinition>(screen, width,  250, height,
 				DefinitionManager.getTrack(settings.track),
@@ -286,9 +286,9 @@ public class TrackGui implements IScreen {
 				settings.isPreview = isPreviewCB.isChecked();
 			}
 		};
-		ytop += height;
+//		ytop += height;
 
-		isGradeCrossingCB = new CheckBox(screen, xtop+2, ytop+2, GuiText.SELECTOR_GRADE_CROSSING.toString(), settings.isGradeCrossing) {
+		isGradeCrossingCB = new CheckBox(screen, xtop+102, ytop+2, GuiText.SELECTOR_GRADE_CROSSING.toString(), settings.isGradeCrossing) {
 			@Override
 			public void onClick(Player.Hand hand) {
 				settings.isGradeCrossing = isGradeCrossingCB.isChecked();

--- a/src/main/java/cam72cam/immersiverailroading/render/multiblock/BoilerRollerRender.java
+++ b/src/main/java/cam72cam/immersiverailroading/render/multiblock/BoilerRollerRender.java
@@ -43,7 +43,7 @@ public class BoilerRollerRender implements IMultiblockRender {
 
 		state.translate(0.5, 0, 0.5);
 		state.rotate(te.getRotation() - 90, 0, 1, 0);
-		state.translate(-3.35, 0, -2.5);
+		state.translate(-3.5, 0, -2.5);
 
 		try (OBJRender.Binding vbo = model.binder().bind(state)) {
 			//TODO better animation


### PR DESCRIPTION
In default 16:9 screen TrackGUI's left lower panel would cover some of upper panel's elements, this pr improves that by making isPreviewCB and isGradeCrossingCB be on the same line (requires UMC 1.14+ add 1.12-like check box)