### PR TITLE
[Feature] Optimize CubicCurve

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/track/BuilderIterator.java
+++ b/src/main/java/cam72cam/immersiverailroading/track/BuilderIterator.java
@@ -28,7 +28,11 @@ public abstract class BuilderIterator extends BuilderBase implements IIterableTr
 		this(info, world, pos, false);
 	}
 
+	//Not sensitive to dynamic stepSize, like physics system
 	public abstract List<PosStep> getPath(double stepSize);
+
+	//Sensitive to dynamic stepSize, return the changed stepSize as well
+	public abstract Pair<Double, List<PosStep>> getPathForRender(double targetStepSize);
 
 	public BuilderIterator(RailInfo info, World world, Vec3i pos, boolean endOfTrack) {
 		super(info, world, pos);
@@ -166,7 +170,9 @@ public abstract class BuilderIterator extends BuilderBase implements IIterableTr
 		List<VecYawPitch> data = new ArrayList<VecYawPitch>();
 
 		double scale = info.settings.gauge.scale();
-		List<PosStep> points = getPath(scale * info.getTrackModel().spacing);
+		Pair<Double, List<PosStep>> pair = getPathForRender(scale * info.getTrackModel().spacing);
+		List<PosStep> points = pair.getRight();
+        scale = pair.getLeft() / info.getTrackModel().spacing;
 
 		boolean switchStraight = info.switchState == SwitchState.STRAIGHT;
 		int switchSize = 0;
@@ -216,15 +222,15 @@ public abstract class BuilderIterator extends BuilderBase implements IIterableTr
 			}
 			if (angle != 0) {
 				if (direction == TrackDirection.RIGHT) {
-					data.add(new VecYawPitch(switchPos.x, switchPos.y, switchPos.z, switchPos.yaw, switchPos.pitch, (1 - angle / 180) * (float) info.settings.gauge.scale(), "RAIL_LEFT"));
-					data.add(new VecYawPitch(cur.x, cur.y, cur.z, cur.yaw, cur.pitch, (1 + angle / 180) * (float) info.settings.gauge.scale(), "RAIL_RIGHT"));
+					data.add(new VecYawPitch(switchPos.x, switchPos.y, switchPos.z, switchPos.yaw, switchPos.pitch, (1 - angle / 180) * (float) scale, "RAIL_LEFT"));
+					data.add(new VecYawPitch(cur.x, cur.y, cur.z, cur.yaw, cur.pitch, (1 + angle / 180) * (float) scale, "RAIL_RIGHT"));
 				} else {
-					data.add(new VecYawPitch(cur.x, cur.y, cur.z, cur.yaw, cur.pitch, (1 - angle / 180) * (float) info.settings.gauge.scale(), "RAIL_LEFT"));
-					data.add(new VecYawPitch(switchPos.x, switchPos.y, switchPos.z, switchPos.yaw, switchPos.pitch, (1 + angle / 180) * (float) info.settings.gauge.scale(), "RAIL_RIGHT"));
+					data.add(new VecYawPitch(cur.x, cur.y, cur.z, cur.yaw, cur.pitch, (1 - angle / 180) * (float) scale, "RAIL_LEFT"));
+					data.add(new VecYawPitch(switchPos.x, switchPos.y, switchPos.z, switchPos.yaw, switchPos.pitch, (1 + angle / 180) * (float) scale, "RAIL_RIGHT"));
 				}
 				data.add(new VecYawPitch(cur.x, cur.y, cur.z, cur.yaw, cur.pitch, "RAIL_BASE"));
 			} else {
-				data.add(new VecYawPitch(cur.x, cur.y, cur.z, cur.yaw, cur.pitch));
+				data.add(new VecYawPitch(cur.x, cur.y, cur.z, cur.yaw, cur.pitch, (float) scale));
 			}
 		}
 		

--- a/src/main/java/cam72cam/immersiverailroading/track/CubicCurve.java
+++ b/src/main/java/cam72cam/immersiverailroading/track/CubicCurve.java
@@ -91,6 +91,7 @@ public class CubicCurve {
 
         resRev.add(p2);
         double precision = 5;
+        double stepSizeSquared = stepSize * stepSize;
 
         double t = 0;
         while (t <= 0.5) {
@@ -101,7 +102,7 @@ public class CubicCurve {
 
                 for (;t < 1 + delta; t+=delta) {
                     Vec3d pos = position(t);
-                    if (pos.distanceTo(prev) > stepSize) {
+                    if (pos.distanceToSquared(prev) > stepSizeSquared) {
                         // We passed it, just barely
                         t -= delta;
                         break;
@@ -122,7 +123,7 @@ public class CubicCurve {
 
                 for (;t > lt - delta; t-=delta) {
                     Vec3d pos = position(t);
-                    if (pos.distanceTo(prev) > stepSize) {
+                    if (pos.distanceToSquared(prev) > stepSizeSquared) {
                         // We passed it, just barely
                         t += delta;
                         break;
@@ -134,6 +135,11 @@ public class CubicCurve {
             }
         }
         Collections.reverse(resRev);
+        //For some reason these 2 point may be too close, so check here
+        if(res.get(res.size() - 1).distanceToSquared(resRev.get(0)) <= 0.0001 * stepSizeSquared){//ie.0.01 * stepSize
+            Vec3d revStart = resRev.remove(0);
+            res.set(res.size() - 1, res.get(res.size() - 1).add(revStart).scale(0.5));
+        }
         res.addAll(resRev);
         return res;
     }


### PR DESCRIPTION
Thanks to @cam72cam's advice, this PR partially overhauls the model algorithm to optimize performance and prevent track overlap issues caused by iterating from both sides of the curve.
Example:
Old method: 
<img width="1920" height="1001" alt="2025-08-10_09 18 17" src="https://github.com/user-attachments/assets/2e579a40-2558-4026-b9eb-c800e1f1ba98" />
New method:
<img width="1920" height="1001" alt="2025-08-10_09 08 14" src="https://github.com/user-attachments/assets/ff2d5b0d-e3a6-491e-9d02-4f017ab75431" />
Additionally, the generation code is now over 4x faster with the new method, depending on actual curve.
