### PR TITLE
[Fix] Diesel throttle glitches when trying to set it at a non-notched value

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/entity/Locomotive.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/Locomotive.java
@@ -25,7 +25,6 @@ import java.util.UUID;
 import static cam72cam.immersiverailroading.library.PhysicalMaterials.*;
 
 public abstract class Locomotive extends FreightTank {
-	private static final float throttleDelta = 0.04f;
 	private static final float trainBrakeNotch = 0.04f;
 
 	@TagField("deadMansSwitch")
@@ -147,22 +146,22 @@ public abstract class Locomotive extends FreightTank {
 				}
             break;
 		case THROTTLE_UP:
-			setThrottle(getThrottle() + throttleDelta);
+			setThrottle(getThrottle() + getThrottleDelta());
 			break;
 		case THROTTLE_ZERO:
 			setThrottle(0f);
 			break;
 		case THROTTLE_DOWN:
-			setThrottle(getThrottle() - throttleDelta);
+			setThrottle(getThrottle() - getThrottleDelta());
 			break;
 		case REVERSER_UP:
 			if (linkThrottleReverser) {
 				float mixed = getThrottle() * (getReverser() >= 0 ? 1 : -1);
 				if (mixed < 0) {
-					setRealThrottle(-mixed - throttleDelta);
+					setRealThrottle(-mixed - getThrottleDelta());
 					setReverser(-1);
 				} else {
-					setRealThrottle(mixed + throttleDelta);
+					setRealThrottle(mixed + getThrottleDelta());
 					setReverser(1);
 				}
 			} else {
@@ -179,10 +178,10 @@ public abstract class Locomotive extends FreightTank {
 			if (linkThrottleReverser) {
 				float mixed = getThrottle() * (getReverser() >= 0 ? 1 : -1);
 				if (mixed > 0) {
-					setRealThrottle(mixed - throttleDelta);
+					setRealThrottle(mixed - getThrottleDelta());
 					setReverser(1);
 				} else {
-					setRealThrottle(-mixed + throttleDelta);
+					setRealThrottle(-mixed + getThrottleDelta());
 					setReverser(-1);
 				}
 			} else {
@@ -220,7 +219,7 @@ public abstract class Locomotive extends FreightTank {
 
 
 	protected float getReverserDelta() {
-		return throttleDelta;
+		return 0.04f;
 	}
 
 	public void onDrag(Control<?> component, double newValue) {
@@ -421,8 +420,8 @@ public abstract class Locomotive extends FreightTank {
 		}
 		return 0;
 	}
-	
-	public double getTractiveEffortNewtons(Speed speed) {	
+
+	public double getTractiveEffortNewtons(Speed speed) {
 		if (!this.isBuilt()) {
 			return 0;
 		}
@@ -482,7 +481,7 @@ public abstract class Locomotive extends FreightTank {
 			((Locomotive) stock).setRealIndependentBrake(this.getIndependentBrake());
 		}
 	}
-	
+
 	public float getThrottle() {
 		return throttle;
 	}
@@ -500,6 +499,9 @@ public abstract class Locomotive extends FreightTank {
 			setControlPositions(ModelComponentType.THROTTLE_BRAKE_X, getThrottle()/2 + (1- getTrainBrake())/2);
 		}
 	}
+	public float getThrottleDelta() {
+		return 0.04F;
+	};
 
 	public float getReverser() {
 		return reverser;

--- a/src/main/java/cam72cam/immersiverailroading/entity/LocomotiveDiesel.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/LocomotiveDiesel.java
@@ -131,6 +131,11 @@ public class LocomotiveDiesel extends Locomotive {
 	}
 
 	@Override
+	public float getThrottleDelta() {
+		return 1F / this.getDefinition().getThrottleNotches();
+	}
+
+	@Override
 	public boolean providesElectricalPower() {
 		return this.isRunning();
 	}
@@ -142,12 +147,9 @@ public class LocomotiveDiesel extends Locomotive {
 
 	@Override
 	public void setThrottle(float newThrottle) {
-		int notches = getDefinition().getThrottleNotches();
-		if (newThrottle > getThrottle()) {
-			super.setThrottle((float) (Math.ceil(newThrottle * notches) / notches));
-		} else {
-			super.setThrottle((float) (Math.floor(newThrottle * notches) / notches));
-		}
+		int targetNotch = Math.round(newThrottle / getThrottleDelta());
+		//issue #1526: when dragging or control with augment throttle glitches
+		super.setThrottle(targetNotch * getThrottleDelta());
 	}
 
 	@Override


### PR DESCRIPTION
It is reported in #1526 that when using augment to control diesel throttle it will jump between 2 neighbour notches as the code doesn't expect a constant middle value input, and after testing this also happens when player trying to drag them in GUI.
This pr fixes it by using Math.round