### PR TITLE
[Feature & I18n] Add translations to hard-coded string

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/gui/PaintBrushPicker.java
+++ b/src/main/java/cam72cam/immersiverailroading/gui/PaintBrushPicker.java
@@ -59,7 +59,8 @@ public class PaintBrushPicker implements IScreen {
             }
         }.setVisible(true);
 
-        Slider zoom_slider = new Slider(screen, xtop + width, (int) (GUIHelpers.getScreenHeight()*0.75 - height), "Zoom: ", 0.1, 2, 1, true) {
+        Slider zoom_slider = new Slider(screen, xtop + width, (int) (GUIHelpers.getScreenHeight()*0.75 - height),
+                                        GuiText.SLIDER_ZOOM.toString(), 0.1, 2, 1, true) {
             @Override
             public void onSlider() {
                 zoom = this.getValue();
@@ -67,21 +68,24 @@ public class PaintBrushPicker implements IScreen {
         };
 
         width = 80;
-        Button random = new Button(screen, GUIHelpers.getScreenWidth() / 2 - width, ytop, width, height, "Random") {
+        Button random = new Button(screen, GUIHelpers.getScreenWidth() / 2 - width, ytop, width, height,
+                                   GuiText.SELECTOR_PAINTBRUSH_RANDOM.toString()) {
             @Override
             public void onClick(Player.Hand hand) {
                 variant = ItemPaintBrush.nextRandomTexture(stock, variant);
             }
         };
 
-        Button apply = new Button(screen, GUIHelpers.getScreenWidth() / 2 - width, (int) (GUIHelpers.getScreenHeight()*0.75 - height*2), width, height, "Apply to Stock") {
+        Button apply = new Button(screen, GUIHelpers.getScreenWidth() / 2 - width, (int) (GUIHelpers.getScreenHeight()*0.75 - height*2),
+                                  width, height, GuiText.SELECTOR_PAINTBRUSH_TO_STOCK.toString()) {
             @Override
             public void onClick(Player.Hand hand) {
                 new ItemPaintBrush.PaintBrushPacket(stock, PaintBrushMode.GUI, variant, false).sendToServer();
                 screen.close();
             }
         };
-        Button apply_connected = new Button(screen, GUIHelpers.getScreenWidth() / 2 - width, (int) (GUIHelpers.getScreenHeight()*0.75 - height), width, height, "Apply to Train") {
+        Button apply_connected = new Button(screen, GUIHelpers.getScreenWidth() / 2 - width, (int) (GUIHelpers.getScreenHeight()*0.75 - height),
+                                            width, height, GuiText.SELECTOR_PAINTBRUSH_TO_TRAIN.toString()) {
             @Override
             public void onClick(Player.Hand hand) {
                 new ItemPaintBrush.PaintBrushPacket(stock, PaintBrushMode.GUI, variant, true).sendToServer();

--- a/src/main/java/cam72cam/immersiverailroading/gui/TrackGui.java
+++ b/src/main/java/cam72cam/immersiverailroading/gui/TrackGui.java
@@ -296,7 +296,8 @@ public class TrackGui implements IScreen {
 		};
 		ytop += height;
 
-		Slider zoom_slider = new Slider(screen, GUIHelpers.getScreenWidth() / 2 - 150, (int) (GUIHelpers.getScreenHeight()*0.75 - height), "Zoom: ", 0.1, 2, 1, true) {
+		Slider zoom_slider = new Slider(screen, GUIHelpers.getScreenWidth() / 2 - 150, (int) (GUIHelpers.getScreenHeight()*0.75 - height),
+										GuiText.SLIDER_ZOOM.toString(), 0.1, 2, 1, true) {
 			@Override
 			public void onSlider() {
 				zoom = this.getValue();

--- a/src/main/java/cam72cam/immersiverailroading/gui/components/ListSelector.java
+++ b/src/main/java/cam72cam/immersiverailroading/gui/components/ListSelector.java
@@ -1,6 +1,6 @@
 package cam72cam.immersiverailroading.gui.components;
 
-import cam72cam.immersiverailroading.gui.TrackGui;
+import cam72cam.immersiverailroading.library.GuiText;
 import cam72cam.mod.entity.Player;
 import cam72cam.mod.gui.helpers.GUIHelpers;
 import cam72cam.mod.gui.screen.Button;
@@ -34,20 +34,20 @@ public abstract class ListSelector<T> {
         this.rawOptions = rawOptions;
         this.currentValue = currentValue;
         visible = false;
+        page = 0;
 
         int xtop = -GUIHelpers.getScreenWidth() / 2 + xOff;
         int ytop = -GUIHelpers.getScreenHeight() / 4;
 
         search = new TextField(screen, xtop, ytop, width - 1, height);
 
-        pagination = new Button(screen, xtop, ytop + height, width + 1, height, "Page") {
+        pagination = new Button(screen, xtop, ytop + height, width + 1, height, "") {
             @Override
             public void onClick(Player.Hand hand) {
                 page += hand == Player.Hand.PRIMARY ? 1 : -1;
                 updateSearch(search.getText());
             }
         };
-        page = 0;
 
         pageSize = Math.max(1, GUIHelpers.getScreenHeight() / height - 2);
 
@@ -109,7 +109,7 @@ public abstract class ListSelector<T> {
             page = nPages - 1;
         }
 
-        pagination.setText(String.format("Page %s of %s", page + 1, Math.max(1, nPages)));
+        pagination.setText(GuiText.SELECTOR_PAGE.toString(page + 1, Math.max(1, nPages)));
 
         options.forEach(b -> {
             b.setText("");

--- a/src/main/java/cam72cam/immersiverailroading/items/ItemManual.java
+++ b/src/main/java/cam72cam/immersiverailroading/items/ItemManual.java
@@ -1,6 +1,7 @@
 package cam72cam.immersiverailroading.items;
 
 import cam72cam.immersiverailroading.ImmersiveRailroading;
+import cam72cam.immersiverailroading.library.ChatText;
 import cam72cam.immersiverailroading.library.GuiText;
 import cam72cam.immersiverailroading.multiblock.Multiblock;
 import cam72cam.immersiverailroading.multiblock.MultiblockRegistry;
@@ -48,7 +49,7 @@ public class ItemManual extends CustomItem {
 		if (mb == null) {
 			return super.getTooltip(stack);
 		}
-		return Collections.singletonList(GuiText.SELECTOR_TYPE.toString(mb.getName()));
+		return Collections.singletonList(GuiText.SELECTOR_TYPE.toString(mb.getTranslatedName()));
 	}
 
 	@Override
@@ -60,7 +61,8 @@ public class ItemManual extends CustomItem {
 				List<Multiblock> keys = MultiblockRegistry.registered();
 				data.multiblock = keys.get((keys.indexOf(data.multiblock) + 1) % (keys.size()));
 				data.write();
-				player.sendMessage(PlayerMessage.direct("Placing: " + data.multiblock.getName()));
+
+				player.sendMessage(ChatText.MULTIBLOCK_SELECTING.getMessage(data.multiblock.getTranslatedName()));
 			}
 		} else {
 			if (world.isClient) {

--- a/src/main/java/cam72cam/immersiverailroading/items/ItemRadioCtrlCard.java
+++ b/src/main/java/cam72cam/immersiverailroading/items/ItemRadioCtrlCard.java
@@ -1,6 +1,7 @@
 package cam72cam.immersiverailroading.items;
 
 import cam72cam.immersiverailroading.ImmersiveRailroading;
+import cam72cam.immersiverailroading.library.GuiText;
 import cam72cam.mod.item.*;
 import cam72cam.mod.serialization.TagField;
 
@@ -34,7 +35,7 @@ public class ItemRadioCtrlCard extends CustomItem {
     @Override
     public List<String> getTooltip(ItemStack stack) {
         Data d = new Data(stack);
-        return Collections.singletonList(d.linked == null ? "Not linked to any locomotive" : "Linked to: " + d.linked);
+        return Collections.singletonList(d.linked == null ? GuiText.RADIO_CARD_NOT_LINKED.toString() : GuiText.RADIO_CARD_LINKED_TO.toString(d.linked));
     }
 
     public static class Data extends ItemDataSerializer {

--- a/src/main/java/cam72cam/immersiverailroading/items/ItemTrackBlueprint.java
+++ b/src/main/java/cam72cam/immersiverailroading/items/ItemTrackBlueprint.java
@@ -104,9 +104,9 @@ public class ItemTrackBlueprint extends CustomItem {
 		String indented = "    - %s";
 
 		tooltip.add(GuiText.TRACK_TYPE.toString(""));
-		tooltip.add(String.format(indented, settings.type));
-		tooltip.add(String.format(indented, settings.length + " Meters"));
-		tooltip.add(String.format(indented, settings.gauge + " Gauge"));
+		tooltip.add(String.format(indented, GuiText.TRACK_TYPE.toString(settings.type)));
+		tooltip.add(String.format(indented, GuiText.TRACK_LENGTH.toString(settings.length)));
+		tooltip.add(String.format(indented, GuiText.TRACK_GAUGE.toString(settings.gauge)));
 		// TODO move checks for if applicable to enum
 		if (settings.type.hasQuarters()) {
 			tooltip.add(String.format(indented, GuiText.TRACK_QUARTERS.toString(settings.degrees)));

--- a/src/main/java/cam72cam/immersiverailroading/library/ChatText.java
+++ b/src/main/java/cam72cam/immersiverailroading/library/ChatText.java
@@ -36,6 +36,7 @@ public enum ChatText {
 	SWITCH_RESET("switch_state.reset"),
 	SWITCH_CANT_RESET("switch_state.cant_reset"),
 	SWITCH_ALREADY_RESET("switch_state.already_reset"),
+	MULTIBLOCK_SELECTING("multiblock.select"),
 	;
 	
 	private String value;

--- a/src/main/java/cam72cam/immersiverailroading/library/GuiText.java
+++ b/src/main/java/cam72cam/immersiverailroading/library/GuiText.java
@@ -53,6 +53,9 @@ public enum GuiText {
 	TRACK_SWITCHER_TOOLTIP("item.track_exchanger"),
 	PAINT_BRUSH_MODE_TOOLTIP("item.paint_brush.mode"),
 	PAINT_BRUSH_DESCRIPTION_TOOLTIP("item.paint_brush.description"),
+
+	ON("overlay.on"),
+	OFF("overlay.off"),
 	NONE("none"),
 	;
 

--- a/src/main/java/cam72cam/immersiverailroading/library/GuiText.java
+++ b/src/main/java/cam72cam/immersiverailroading/library/GuiText.java
@@ -6,6 +6,8 @@ public enum GuiText {
 	LABEL_BRAKE("label.brake"),
 	LABEL_THROTTLE("label.throttle"),
 	LABEL_REVERSER("label.reverser"),
+	SLIDER_ZOOM("slider.zoom"), //Need colon
+	SELECTOR_PAGE("selector.page"),
 	SELECTOR_TYPE("selector.type"),
 	SELECTOR_QUARTERS("selector.quarters"),
 	SELECTOR_CURVOSITY("selector.curvosity"),
@@ -22,6 +24,9 @@ public enum GuiText {
 	SELECTOR_PLATE_BOILER("selector.plate_boiler"),
 	SELECTOR_CAST_SINGLE("selector.cast_single"),
 	SELECTOR_CAST_REPEAT("selector.cast_repeat"),
+	SELECTOR_PAINTBRUSH_RANDOM("selector.paintbrush_random"),
+	SELECTOR_PAINTBRUSH_TO_STOCK("selector.paintbrush_apply_to_stock"),
+	SELECTOR_PAINTBRUSH_TO_TRAIN("selector.paintbrush_apply_to_train"),
 
 	TRACK_TYPE("track.type"),
 	TRACK_LENGTH("track.length"),
@@ -48,6 +53,8 @@ public enum GuiText {
 	TEXTURE_TOOLTIP("stock.texture"),
 	SWITCH_KEY_TOOLTIP("item.switch_key"),
 	SWITCH_KEY_DATA_TOOLTIP("item.switch_key.data"),
+	RADIO_CARD_LINKED_TO("item.radio_card.linked_to"),
+	RADIO_CARD_NOT_LINKED("item.radio_card.not_linked"),
 	MODELER_TOOLTIP("stock.modeler"),
 	PACK_TOOLTIP("stock.pack"),
 	TRACK_SWITCHER_TOOLTIP("item.track_exchanger"),

--- a/src/main/java/cam72cam/immersiverailroading/library/ModelComponentType.java
+++ b/src/main/java/cam72cam/immersiverailroading/library/ModelComponentType.java
@@ -1,5 +1,9 @@
 package cam72cam.immersiverailroading.library;
 
+import cam72cam.mod.text.TextUtil;
+
+import java.util.Locale;
+
 public enum ModelComponentType {
 	// STANDARD
 	BOGEY_POS_WHEEL_X("BOGEY_#POS#_WHEEL_#ID#"),
@@ -134,7 +138,31 @@ public enum ModelComponentType {
 		return group.contains("CHIMNEY_") || group.contains("CHIMINEY_") || group.contains("PRESSURE_VALVE_") || group.contains("EXHAUST_") || group.contains("CARGO_ITEMS");
 	}
 
-    public static class ModelPosition {
+	public String getOverlayName() {
+		//Get name and remove _X
+		String primary = this.name().substring(0, this.name().length() - 2);
+		switch (this) {
+			case CYLINDER_DRAIN_CONTROL_X:
+			case BELL_CONTROL_X:
+			case WHISTLE_CONTROL_X:
+			case HORN_CONTROL_X:
+				//Remove _CONTROL
+				primary = primary.substring(0, primary.length() - 8);
+				//Fallthrough
+			case TRAIN_BRAKE_X:
+			case INDEPENDENT_BRAKE_X:
+			case THROTTLE_X:
+			case REVERSER_X:
+			case THROTTLE_BRAKE_X:
+			case ENGINE_START_X:
+				return TextUtil.translate("part.immersiverailroading:controls." + primary.toLowerCase(Locale.ROOT));
+            default:
+				//Unexpected behaviour
+				return "";
+		}
+	}
+
+	public static class ModelPosition {
 		private static final ModelPosition INNER = new ModelPosition("INNER");
 		public static final ModelPosition LEFT = new ModelPosition("LEFT");
 		public static final ModelPosition INNER_LEFT = INNER.and(LEFT);

--- a/src/main/java/cam72cam/immersiverailroading/model/part/Control.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/Control.java
@@ -20,6 +20,7 @@ import cam72cam.mod.model.obj.OBJGroup;
 import cam72cam.mod.render.GlobalRender;
 import cam72cam.mod.render.opengl.RenderState;
 import cam72cam.mod.text.TextColor;
+import cam72cam.mod.text.TextUtil;
 import cam72cam.mod.util.Axis;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.text.WordUtils;
@@ -313,7 +314,20 @@ public class Control<T extends EntityMoveableRollingStock> extends Interactable<
                     labelstate = String.format(" (%d%%)", (int)(percent * 100));
                 }
         }
-        String str = (label != null ? label : part.type.getOverlayName()) + labelstate;
+        //Try to translate label
+        String str;
+        if (this.label != null) {
+            String[] parts = stock.getDefinitionID().split("/");
+            String key1 = "label.immersiverailroading:" + parts[1] + "." + parts[2].replace(".json", "") + "." + label;
+            str = TextUtil.translate(key1);
+            if (str.equals(key1)) {
+                String key2 = "label.immersiverailroading:" + label;
+                str = TextUtil.translate(key2).equals(key2) ? label : TextUtil.translate(key2);
+            }
+        } else {
+            str = part.type.getOverlayName();
+        }
+        str += labelstate;
         if (isPressed) {
             str = TextColor.BOLD.wrap(str);
         }

--- a/src/main/java/cam72cam/immersiverailroading/model/part/Control.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/Control.java
@@ -3,6 +3,7 @@ package cam72cam.immersiverailroading.model.part;
 import cam72cam.immersiverailroading.ConfigGraphics;
 import cam72cam.immersiverailroading.entity.EntityMoveableRollingStock;
 import cam72cam.immersiverailroading.entity.EntityRollingStock;
+import cam72cam.immersiverailroading.library.GuiText;
 import cam72cam.immersiverailroading.library.ModelComponentType;
 import cam72cam.immersiverailroading.library.ModelComponentType.ModelPosition;
 import cam72cam.immersiverailroading.model.ModelState;
@@ -297,7 +298,7 @@ public class Control<T extends EntityMoveableRollingStock> extends Interactable<
                     percent *= -2;
                 }
                 if (toggle || press) {
-                    labelstate = percent == 1 ? " (On)" : " (Off)";
+                    labelstate = percent == 1 ? " ("+ GuiText.ON +")" : " ("+ GuiText.OFF +")";
                 } else {
                     labelstate = String.format(" (%d%%)", (int)(percent * 100));
                 }
@@ -307,12 +308,12 @@ public class Control<T extends EntityMoveableRollingStock> extends Interactable<
                     return;
                 }
                 if (toggle || press) {
-                    labelstate = percent == 1 ? " (On)" : " (Off)";
+                    labelstate = percent == 1 ? " ("+ GuiText.ON +")" : " ("+ GuiText.OFF +")";
                 } else {
                     labelstate = String.format(" (%d%%)", (int)(percent * 100));
                 }
         }
-        String str = (label != null ? label : formatLabel(part.type)) + labelstate;
+        String str = (label != null ? label : part.type.getOverlayName()) + labelstate;
         if (isPressed) {
             str = TextColor.BOLD.wrap(str);
         }

--- a/src/main/java/cam72cam/immersiverailroading/multiblock/Multiblock.java
+++ b/src/main/java/cam72cam/immersiverailroading/multiblock/Multiblock.java
@@ -20,6 +20,7 @@ import cam72cam.mod.math.Rotation;
 import cam72cam.mod.math.Vec3d;
 import cam72cam.mod.math.Vec3i;
 import cam72cam.mod.text.PlayerMessage;
+import cam72cam.mod.text.TextUtil;
 import cam72cam.mod.world.BlockInfo;
 import cam72cam.mod.world.World;
 
@@ -201,6 +202,10 @@ public abstract class Multiblock {
 
 	public String getName() {
 		return name;
+	}
+
+	public String getTranslatedName() {
+		return TextUtil.translate("multiblock.immersiverailroading:"+getName().toLowerCase(Locale.ROOT));
 	}
 
 	public abstract class MultiblockInstance {

--- a/src/main/resources/assets/immersiverailroading/lang/en_us.lang
+++ b/src/main/resources/assets/immersiverailroading/lang/en_us.lang
@@ -286,3 +286,61 @@ ir_keys.bell=Sound Bell
 ir_keys.dead_mans_switch=Deadman's Switch
 ir_keys.start_stop_engine=Start/Stop engine
 ir_keys.config=Config
+
+# Default pack's train name
+immersiverailroading:entity.locomotives.a1_peppercorn=A1 Peppercorn
+immersiverailroading:entity.locomotives.a5_switcher=A5 Switcher
+immersiverailroading:entity.locomotives.alco_rs1=RS-1
+immersiverailroading:entity.locomotives.big_boy=Big Boy (4000 class)
+immersiverailroading:entity.locomotives.br01=br01
+immersiverailroading:entity.locomotives.class_38=Class 38
+immersiverailroading:entity.locomotives.cooke_mogul=DSP&P Mogul
+immersiverailroading:entity.locomotives.e6_atlantic=E6 Atlantic
+immersiverailroading:entity.locomotives.emd_sd40-2=EMD SD40-2
+immersiverailroading:entity.locomotives.emd_sw1500=SW1500
+immersiverailroading:entity.locomotives.firefly=Firefly
+immersiverailroading:entity.locomotives.ge_40_ton_boxcab=Class B-B-70/70-4HM829 Boxcab
+immersiverailroading:entity.locomotives.ge_b40_8=GE B40-8
+immersiverailroading:entity.locomotives.ge_b40_8w=GE B40-8w
+immersiverailroading:entity.locomotives.ge_c44_9cw=GE C44-9CW
+immersiverailroading:entity.locomotives.iron_duke=Iron Duke
+immersiverailroading:entity.locomotives.k36=D&RGW K36
+immersiverailroading:entity.locomotives.k4_pacific=K4 Pacific
+immersiverailroading:entity.locomotives.rodgers_460=Rodgers Ten Wheeler
+immersiverailroading:entity.locomotives.skookum=Skookum 2-4-4-2
+immersiverailroading:entity.tender.a1_peppercorn_tender=A1 Peppercorn Tender
+immersiverailroading:entity.tender.a5_tender=A5 Slope Tender
+immersiverailroading:entity.tender.big_boy_tender=Big Boy (4000 class) Tender
+immersiverailroading:entity.tender.br01_tender=drg class 01 tender
+immersiverailroading:entity.tender.class_38_tender=Class 38 Tender
+immersiverailroading:entity.tender.cooke_tender=Cooke Tender
+immersiverailroading:entity.tender.e6_tender=E6 Atlantic Tender
+immersiverailroading:entity.tender.k4_tender=K4 Pacific Tender
+immersiverailroading:entity.tender.k36_tender=K36 Tender
+immersiverailroading:entity.tender.rodgers_460_tender=Rodgers Ten Wheeler Tender
+immersiverailroading:entity.tender.skookum_tender=Skookum Tender
+
+immersiverailroading:entity.hand_car.hand_car_1=Hand Car
+
+immersiverailroading:entity.passenger.b70baggage=PRR B70 Baggage
+immersiverailroading:entity.passenger.br_coach_mk1=BR Coach MK1
+immersiverailroading:entity.passenger.p70coach1=PRR P70 Coach 1
+
+immersiverailroading:entity.freight.70t_hopper_slsf=70T Hopper SLSF
+immersiverailroading:entity.freight.attx_flatcar_1=ATTX Flatcar 1
+immersiverailroading:entity.freight.boxcar_x26=Box Car X26
+immersiverailroading:entity.freight.drgw_1000class_gondola=1000 Series Gondola
+immersiverailroading:entity.freight.drgw_3000class_boxcar=3000 Series Boxcar
+immersiverailroading:entity.freight.drgw_5500class_stockcar=5500 Series Stockcar
+immersiverailroading:entity.freight.drgw_rail_and_tie_outfit=Rail & Tie Car
+immersiverailroading:entity.freight.dw_gondola=DW Gondola
+immersiverailroading:entity.freight.n5c_cabin_car=N5c Caboose
+immersiverailroading:entity.freight.prr_flatcar_1=PRR Flatcar 1
+immersiverailroading:entity.freight.russell_snow_plow=Russell Snow Plow
+immersiverailroading:entity.freight.usra_boxcar_classrr40=USRA Boxcar Class RR-40
+immersiverailroading:entity.freight.usra_hopper_55t=USRA Hopper 55T
+immersiverailroading:entity.freight.waycar=Waycar
+
+immersiverailroading:entity.tank.kamx_t=Kamx T
+immersiverailroading:entity.tank.slag_car_1=Slag Car 1
+immersiverailroading:entity.tank.tank_us2=Tank US 2

--- a/src/main/resources/assets/immersiverailroading/lang/en_us.lang
+++ b/src/main/resources/assets/immersiverailroading/lang/en_us.lang
@@ -117,6 +117,9 @@ gui.immersiverailroading:stock.weight=Weight:          %s Kg
 gui.immersiverailroading:stock.modeler=Modeler:        %s
 gui.immersiverailroading:stock.pack=Pack:            %s
 
+gui.immersiverailroading:overlay.on=On
+gui.immersiverailroading:overlay.off=Off
+
 immersiverailroading:gauge.brunel=Brunel
 immersiverailroading:gauge.standard=Standard
 immersiverailroading:gauge.narrow=Narrow
@@ -202,6 +205,16 @@ part.immersiverailroading:component.reach_rod=Reach Rod
 part.immersiverailroading:component.walcherts_linkage=Walcherts Linkage
 part.immersiverailroading:component.valve_rod=Valve Gear Component
 
+part.immersiverailroading:controls.cylinder_drain=Cylinder Drain
+part.immersiverailroading:controls.bell=Bell
+part.immersiverailroading:controls.whistle=Whistle
+part.immersiverailroading:controls.horn=Horn
+part.immersiverailroading:controls.train_brake=Train Brake
+part.immersiverailroading:controls.independent_brake=Independent Brake
+part.immersiverailroading:controls.throttle=Throttle
+part.immersiverailroading:controls.reverser=Reverser
+part.immersiverailroading:controls.throttle_brake=Throttle Brake
+part.immersiverailroading:controls.engine_start=Engine Start
 
 immersiverailroading:crafting_type.casting=Casting
 immersiverailroading:crafting_type.casting_hammer=Casting,Power Hammer

--- a/src/main/resources/assets/immersiverailroading/lang/en_us.lang
+++ b/src/main/resources/assets/immersiverailroading/lang/en_us.lang
@@ -62,10 +62,13 @@ chat.immersiverailroading:switch_state.locked=Switch locked to %s
 chat.immersiverailroading:switch_state.reset=The last-locked switch has been wirelessly unlocked!
 chat.immersiverailroading:switch_state.cant_reset=You haven't locked any switches with this key!
 chat.immersiverailroading:switch_state.already_reset=The last-locked switch is already unlocked!
+chat.immersiverailroading:multiblock.select=Select multiblock: %s
 
 gui.immersiverailroading:label.brake=Brake
 gui.immersiverailroading:label.throttle=Throttle
 gui.immersiverailroading:label.reverser=Reverser
+gui.immersiverailroading:slider.zoom=Zoom: %s
+gui.immersiverailroading:selector.page=Page %s of %s
 gui.immersiverailroading:selector.type=Type: %s
 gui.immersiverailroading:selector.gauge=Gauge: %s
 gui.immersiverailroading:selector.track=Track Style: %s
@@ -82,9 +85,15 @@ gui.immersiverailroading:selector.plate_type=Plate Type: %s
 gui.immersiverailroading:selector.plate_boiler=Plate Boiler: %s
 gui.immersiverailroading:selector.cast_single=Single Casting
 gui.immersiverailroading:selector.cast_repeat=Repeat Casting
+gui.immersiverailroading:selector.paintbrush_random=Apply random variant
+gui.immersiverailroading:selector.paintbrush_apply_to_stock=Apply to single stock
+gui.immersiverailroading:selector.paintbrush_apply_to_train=Apply to whole train
 
 gui.immersiverailroading:item.switch_key=Right-Click a switch to cycle between: [ locked straight, locked turn, unlocked ]. Redstone is ignored when locked!
 gui.immersiverailroading:item.switch_key.data=Last locked switch: %s in %s
+
+gui.immersiverailroading:item.radio_card.linked_to=Not linked to any locomotive
+gui.immersiverailroading:item.radio_card.not_linked=Linked to %s
 
 gui.immersiverailroading:item.track_exchanger=Right-Click in air to open the selection gui. Right-Click on a track to change it's track type to the one defined in the gui
 gui.immersiverailroading:item.paint_brush.mode=Current mode: %s
@@ -215,6 +224,12 @@ part.immersiverailroading:controls.throttle=Throttle
 part.immersiverailroading:controls.reverser=Reverser
 part.immersiverailroading:controls.throttle_brake=Throttle Brake
 part.immersiverailroading:controls.engine_start=Engine Start
+
+multiblock.immersiverailroading:boiler_machine=Boiler Machine
+multiblock.immersiverailroading:casting=Casting Basin
+multiblock.immersiverailroading:plate_machine=Plate Machine
+multiblock.immersiverailroading:rail_machine=Rail Machine
+multiblock.immersiverailroading:steam_hammer=Steam Hammer
 
 immersiverailroading:crafting_type.casting=Casting
 immersiverailroading:crafting_type.casting_hammer=Casting,Power Hammer


### PR DESCRIPTION
This PR:
- Adds some new translation keys to replace hard-coded GUI string
- Adds stock names translation keys
- Add a way to translate component label:
    - First it will find label.immersiverailroading:[stock type].[json name].[label text]
    - If not found it will try label.immersiverailroading:[label text]
    - If still not found it will fallback to old code