### PR TITLE
[Fix] Stock not removed if pack not present

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/entity/EntityRollingStock.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/EntityRollingStock.java
@@ -85,6 +85,7 @@ public class EntityRollingStock extends CustomEntity implements ITickable, IClic
 		if (DefinitionManager.getDefinition(defID) == null) {
 			String error = String.format("Missing definition %s, do you have all of the required resource packs?", defID);
 			ImmersiveRailroading.error(error);
+			this.kill();
 			return error;
 		}
 		return null;
@@ -108,8 +109,7 @@ public class EntityRollingStock extends CustomEntity implements ITickable, IClic
 	@Override
 	public void onTick() {
 		if (getWorld().isServer && this.getTickCount() % 5 == 0) {
-			EntityRollingStockDefinition def = DefinitionManager.getDefinition(defID);
-			if (def == null) {
+			if (DefinitionManager.getDefinition(defID) == null) {
 				this.kill();
 			}
 		}


### PR DESCRIPTION
If corresponding pack is not present, stock will refuse to join the world thus never call `kill()`, resulting in the entity never removed until pack loaded(aka "Ghost stock"). This PR fixes that by calling `kill` in `tryJoinWorld`