### PR TITLE
[Feature] Add ability to customize diesel fuel by definition

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/entity/LocomotiveDiesel.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/LocomotiveDiesel.java
@@ -16,8 +16,7 @@ import cam72cam.mod.fluid.Fluid;
 import cam72cam.mod.fluid.FluidStack;
 import cam72cam.mod.serialization.TagField;
 
-import java.util.List;
-import java.util.OptionalDouble;
+import java.util.*;
 
 public class LocomotiveDiesel extends Locomotive {
 
@@ -221,9 +220,12 @@ public class LocomotiveDiesel extends Locomotive {
 		
 		if (this.getLiquidAmount() > 0 && isRunning()) {
 			float consumption = Math.abs(getThrottle()) + 0.05f;
-			float burnTime = BurnUtil.getBurnTime(this.getLiquid());
+			float burnTime = getDefinition().getOverriddenFuels().getOrDefault(this.getLiquid(), 0);
 			if (burnTime == 0) {
-				burnTime = 200; //Default to 200 for unregistered liquids
+				burnTime = BurnUtil.getBurnTime(this.getLiquid());
+			}
+			if (burnTime == 0) {
+				burnTime = 200;
 			}
 			burnTime *= getDefinition().getFuelEfficiency()/100f;
 			burnTime *= (Config.ConfigBalance.locoDieselFuelEfficiency / 100f);
@@ -253,10 +255,11 @@ public class LocomotiveDiesel extends Locomotive {
 
 		setEngineTemperature(engineTemperature);
 	}
-	
+
 	@Override
 	public List<Fluid> getFluidFilter() {
-		return BurnUtil.burnableFluids();
+		Set<Fluid> set = getDefinition().getOverriddenFuels().keySet();
+		return set.isEmpty() ? BurnUtil.burnableFluids() : new ArrayList<>(set);
 	}
 
 	@Override

--- a/src/main/resources/assets/immersiverailroading/rolling_stock/default/diesel.caml
+++ b/src/main/resources/assets/immersiverailroading/rolling_stock/default/diesel.caml
@@ -9,6 +9,10 @@ properties =
     throttle_notches = 8 # Optional: Number of throttle notches in the cab
     dynamic_traction_control = false # If the onboard computer can try to prevent wheel slip
     horn_sustained = False # Optional: Should the horn repeat
+    # fuel_override: "water:1000" # Optional: add fluid filter for this locomotive, and if you want you can also override burntime here
+    # fuel_override: "ethanol:1700"
+    # fuel_override: "gasoline" # "gasoline" will use 100 defined in config as burntime
+    # fuel_override: "lava" # "lava" will be skipped in default environment because it neither exist in default config nor have burntime specified here
 
 sounds =
     idle = "immersiverailroading:sounds/diesel/default/idle.ogg"    # Optional: See sound_definition.caml for details


### PR DESCRIPTION
Resolves #1466, #1382 

This PR gives modeler the ability to lock down which fuels a diesel locomotive accepts and set custom burn times for them right in the stock properties. Add a `fuel_override` list inside `properties`, and the locomotive will ignore anything that isn't on that list.

Each entry follows the pattern `fluid_name` or `fluid_name:burn_time`.

- If a fluid is already defined in the main config, you can simply name it to use its default burn time, or append `:burn_time` to override that value for this locomotive.

- For a fluid not defined in the main config, you must provide a burn time directly; otherwise it will be skipped.

For instance,

```json
...
"properties": {
    ...
    "fuel_override": [
        "water:1000",
        "ethanol:1700",
        "gasoline",
        "lava"
    ]
    ...
},
...
```
In this example configuration:
- The locomotive will only accept `water`, `ethanol`, and `gasoline` as valid fuels.
- `water` uses a custom burn time of `1000` (not defined in the main config, specified directly here).
- `ethanol` overrides the default burn time for this locomotive from the main config with a new value of `1700`.
- `gasoline` falls back to using its predefined burn time (`100` as defined in the main config).
- `lava` will be skipped in default environment because it neither exist in default config nor have burntime specified here