### PR TITLE
[Feature] SI Units

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/ConfigGraphics.java
+++ b/src/main/java/cam72cam/immersiverailroading/ConfigGraphics.java
@@ -1,5 +1,6 @@
 package cam72cam.immersiverailroading;
 
+import cam72cam.immersiverailroading.library.PowerDisplayType;
 import cam72cam.immersiverailroading.library.PressureDisplayType;
 import cam72cam.immersiverailroading.library.SpeedDisplayType;
 import cam72cam.immersiverailroading.library.TemperatureDisplayType;
@@ -25,11 +26,14 @@ public class ConfigGraphics {
 	@Comment( "What unit to use for speedometer. (kmh, mph or ms)" )
 	public static SpeedDisplayType speedUnit = SpeedDisplayType.kmh;
 
-	@Comment("What units to display pressure in (psi, bar)")
+	@Comment("What units to display pressure in (psi, bar, kpa)")
 	public static PressureDisplayType pressureUnit = PressureDisplayType.psi;
 
 	@Comment("What units to display pressure in (psi, bar)")
 	public static TemperatureDisplayType temperatureUnit = TemperatureDisplayType.celcius;
+
+	@Comment("What units to display locomotive power in (W, kW, horsepower)")
+	public static PowerDisplayType powerDisplayType = PowerDisplayType.w;
 
 	@Comment( "How long to keep textures in memory after they have left the screen (higher numbers = smoother game play, lower numbers = less GPU memory used)")
 	@Range(min = 0, max = 100)

--- a/src/main/java/cam72cam/immersiverailroading/entity/HandCar.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/HandCar.java
@@ -27,7 +27,7 @@ public class HandCar extends Locomotive {
 			}
 		}
 		// Same as diesel for now
-		double maxPower_W = this.getDefinition().getHorsePower(gauge) * 745.7d * passengers;
+		double maxPower_W = this.getDefinition().getWatt(gauge) * passengers;
 		double efficiency = 0.82; // Similar to a *lot* of imperial references
 		double speed_M_S = (Math.abs(speed.metric())/3.6);
 		double maxPowerAtSpeed = maxPower_W * efficiency / Math.max(0.001, speed_M_S);

--- a/src/main/java/cam72cam/immersiverailroading/entity/LocomotiveDiesel.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/LocomotiveDiesel.java
@@ -161,7 +161,7 @@ public class LocomotiveDiesel extends Locomotive {
 	@Override
 	public double getAppliedTractiveEffort(Speed speed) {
 		if (isRunning() && (getEngineTemperature() > 75 || !Config.isFuelRequired(gauge))) {
-			double maxPower_W = this.getDefinition().getHorsePower(gauge) * 745.7d;
+			double maxPower_W = this.getDefinition().getWatt(gauge);
 			double efficiency = 0.82; // Similar to a *lot* of imperial references
 			double speed_M_S = (Math.abs(speed.metric())/3.6);
 			double maxPowerAtSpeed = maxPower_W * efficiency / Math.max(0.001, speed_M_S);

--- a/src/main/java/cam72cam/immersiverailroading/entity/LocomotiveSteam.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/LocomotiveSteam.java
@@ -98,7 +98,7 @@ public class LocomotiveSteam extends Locomotive {
 		// This is terrible, but allows wheel slip for both legacy and updated hp vs te
 		double traction_N = Math.max(
 				this.getDefinition().getStartingTractionNewtons(gauge),
-				this.getDefinition().getHorsePower(gauge) * 375 / Math.max(Math.abs(speed.imperial()), 1.0)
+				this.getDefinition().getWatt(gauge) * 0.5 / Math.max(Math.abs(speed.imperial()), 1.0)
 		);
 		if (Config.isFuelRequired(gauge)) {
 			traction_N = traction_N / this.getDefinition().getMaxPSI(gauge) * this.getBoilerPressure();

--- a/src/main/java/cam72cam/immersiverailroading/library/GuiText.java
+++ b/src/main/java/cam72cam/immersiverailroading/library/GuiText.java
@@ -44,7 +44,8 @@ public enum GuiText {
 	TRACK_PLACE_BLUEPRINT_FALSE("track.place_blueprint_false"),
 	
 	LOCO_WORKS("loco.works"),
-	LOCO_HORSE_POWER("loco.horse_power"),
+//	LOCO_HORSE_POWER("loco.horse_power"),
+	LOCO_POWER("loco.power"),
 	LOCO_TRACTION("loco.tractive_effort"),
 	LOCO_MAX_SPEED("loco.max_speed"),
 	GAUGE_TOOLTIP("stock.gauge"),
@@ -68,7 +69,7 @@ public enum GuiText {
 	NONE("none"),
 	;
 
-	private String value;
+	private final String value;
 	GuiText(String value) {
 		this.value = value;
 	}

--- a/src/main/java/cam72cam/immersiverailroading/library/PowerDisplayType.java
+++ b/src/main/java/cam72cam/immersiverailroading/library/PowerDisplayType.java
@@ -1,0 +1,32 @@
+package cam72cam.immersiverailroading.library;
+
+public enum PowerDisplayType {
+    horsepower,
+    w,
+    kw,
+    ;
+
+    public int convertFromWatt(int value) {
+        switch (this) {
+            case w:
+                return value;
+            case kw:
+                return value / 1000;
+            case horsepower:
+            default:
+                return (int) (value * 1.34102209);
+        }
+    }
+
+    public String toUnitString() {
+        switch (this) {
+            case w:
+                return "W";
+            case kw:
+                return "kW";
+            case horsepower:
+            default:
+                return "hp";
+        }
+    }
+}

--- a/src/main/java/cam72cam/immersiverailroading/library/PressureDisplayType.java
+++ b/src/main/java/cam72cam/immersiverailroading/library/PressureDisplayType.java
@@ -1,16 +1,23 @@
 package cam72cam.immersiverailroading.library;
 
-import java.util.Locale;
-
 public enum PressureDisplayType {
     psi,
-    bar;
+    bar,
+    kpa;
 
     public float convertFromPSI(float value) {
-        return this == psi ? value : value * 0.0689476f;
+        switch (this) {
+            case bar: return value * 0.0689476f;
+            case kpa: return value * 6.89476f;
+            default: return value;
+        }
     }
 
     public String toUnitString() {
-        return toString().toUpperCase(Locale.ROOT);
+        switch (this) {
+            case bar: return "BAR";
+            case kpa: return "kPa";
+            default: return "PSI";
+        }
     }
 }

--- a/src/main/java/cam72cam/immersiverailroading/registry/LocomotiveDefinition.java
+++ b/src/main/java/cam72cam/immersiverailroading/registry/LocomotiveDefinition.java
@@ -1,5 +1,6 @@
 package cam72cam.immersiverailroading.registry;
 
+import cam72cam.immersiverailroading.ConfigGraphics;
 import cam72cam.immersiverailroading.ImmersiveRailroading;
 import cam72cam.immersiverailroading.entity.EntityRollingStock;
 import cam72cam.immersiverailroading.util.DataBlock;
@@ -86,7 +87,9 @@ public abstract class LocomotiveDefinition extends FreightDefinition {
         List<String> tips = super.getTooltip(gauge);
         tips.add(GuiText.LOCO_WORKS.toString(this.works));
         if (!isCabCar) {
-            tips.add(GuiText.LOCO_HORSE_POWER.toString(this.getHorsePower(gauge)));
+//            tips.add(GuiText.LOCO_HORSE_POWER.toString(this.getHorsePower(gauge)));
+            int power = ConfigGraphics.powerDisplayType.convertFromWatt(this.getWatt(gauge));
+            tips.add(GuiText.LOCO_POWER.toString(power) + ConfigGraphics.powerDisplayType.toUnitString());
             tips.add(GuiText.LOCO_TRACTION.toString(this.getStartingTractionNewtons(gauge)));
             tips.add(GuiText.LOCO_MAX_SPEED.toString(this.getMaxSpeed(gauge).metricString()));
         }
@@ -98,7 +101,7 @@ public abstract class LocomotiveDefinition extends FreightDefinition {
     }
 
     public int getWatt(Gauge gauge) {
-        return (int) Math.ceil(gauge.scale() * this.power / 1000);
+        return (int) Math.ceil(gauge.scale() * this.power * 1000);
     }
 
     /**

--- a/src/main/java/cam72cam/immersiverailroading/registry/LocomotiveDefinition.java
+++ b/src/main/java/cam72cam/immersiverailroading/registry/LocomotiveDefinition.java
@@ -54,14 +54,14 @@ public abstract class LocomotiveDefinition extends FreightDefinition {
             muliUnitCapable = true;
             factorOfAdhesion = 0;
         } else {
-            if (properties.getValue("horsepower") != null) {
+            try {
                 power = properties.getValue("horsepower").asInteger() * internal_inv_scale * 0.745699872;
-            } else  {
+            } catch (Exception e) {
                 power = properties.getValue("kilo_watt").asInteger() * internal_inv_scale;
             }
-            if (properties.getValue("tractive_effort_lbf") != null) {
+            try {
                 traction = properties.getValue("tractive_effort_lbf").asInteger() * 4.44822 * internal_inv_scale;
-            } else {
+            } catch (Exception e) {
                 traction = properties.getValue("tractive_effort_newton").asInteger() * internal_inv_scale;
             }
             factorOfAdhesion = properties.getValue("factor_of_adhesion").asDouble(4);

--- a/src/main/java/cam72cam/immersiverailroading/registry/LocomotiveDefinition.java
+++ b/src/main/java/cam72cam/immersiverailroading/registry/LocomotiveDefinition.java
@@ -16,8 +16,8 @@ public abstract class LocomotiveDefinition extends FreightDefinition {
     public boolean toggleBell;
     public SoundDefinition bell;
     private String works;
-    private double power;
-    private double traction;
+    private double power;    //kW
+    private double traction; //N
     private Speed maxSpeed;
     private boolean hasRadioEquipment;
     public boolean muliUnitCapable;
@@ -53,8 +53,16 @@ public abstract class LocomotiveDefinition extends FreightDefinition {
             muliUnitCapable = true;
             factorOfAdhesion = 0;
         } else {
-            power = properties.getValue("horsepower").asInteger() * internal_inv_scale;
-            traction = properties.getValue("tractive_effort_lbf").asInteger() * internal_inv_scale;
+            if (properties.getValue("horsepower") != null) {
+                power = properties.getValue("horsepower").asInteger() * internal_inv_scale * 0.745699872;
+            } else  {
+                power = properties.getValue("kilo_watt").asInteger() * internal_inv_scale;
+            }
+            if (properties.getValue("tractive_effort_lbf") != null) {
+                traction = properties.getValue("tractive_effort_lbf").asInteger() * 4.44822 * internal_inv_scale;
+            } else {
+                traction = properties.getValue("tractive_effort_newton").asInteger() * internal_inv_scale;
+            }
             factorOfAdhesion = properties.getValue("factor_of_adhesion").asDouble(4);
             maxSpeed = Speed.fromMetric(properties.getValue("max_speed_kmh").asDouble() * internal_inv_scale);
             muliUnitCapable = properties.getValue("multi_unit_capable").asBoolean();
@@ -86,14 +94,18 @@ public abstract class LocomotiveDefinition extends FreightDefinition {
     }
 
     public int getHorsePower(Gauge gauge) {
-        return (int) Math.ceil(gauge.scale() * this.power);
+        return (int) Math.ceil(gauge.scale() * this.power * 1.34102209);
+    }
+
+    public int getWatt(Gauge gauge) {
+        return (int) Math.ceil(gauge.scale() * this.power / 1000);
     }
 
     /**
      * @return tractive effort in newtons
      */
     public int getStartingTractionNewtons(Gauge gauge) {
-        return (int) Math.ceil(gauge.scale() * this.traction * 4.44822);
+        return (int) Math.ceil(gauge.scale() * this.traction);
     }
 
     public Speed getMaxSpeed(Gauge gauge) {

--- a/src/main/java/cam72cam/immersiverailroading/registry/LocomotiveSteamDefinition.java
+++ b/src/main/java/cam72cam/immersiverailroading/registry/LocomotiveSteamDefinition.java
@@ -51,9 +51,10 @@ public class LocomotiveSteamDefinition extends LocomotiveDefinition {
             DataBlock firebox = data.getBlock("firebox");
 
             tankCapacity_l = properties.getValue("water_capacity_l").asInteger() * internal_inv_scale;
-            if (properties.getValue("max_psi") != null){
+            //Ugly...
+            try {
                 maxPSI = Math.ceil(properties.getValue("max_psi").asInteger() * internal_inv_scale);
-            } else {
+            } catch (Exception e) {
                 maxPSI = Math.ceil(properties.getValue("max_kpa").asInteger() * 0.145033 * internal_inv_scale);
             }
             numSlots = Math.ceil(firebox.getValue("slots").asInteger() * internal_inv_scale);

--- a/src/main/java/cam72cam/immersiverailroading/registry/LocomotiveSteamDefinition.java
+++ b/src/main/java/cam72cam/immersiverailroading/registry/LocomotiveSteamDefinition.java
@@ -51,7 +51,11 @@ public class LocomotiveSteamDefinition extends LocomotiveDefinition {
             DataBlock firebox = data.getBlock("firebox");
 
             tankCapacity_l = properties.getValue("water_capacity_l").asInteger() * internal_inv_scale;
-            maxPSI = Math.ceil(properties.getValue("max_psi").asInteger() * internal_inv_scale);
+            if (properties.getValue("max_psi") != null){
+                maxPSI = Math.ceil(properties.getValue("max_psi").asInteger() * internal_inv_scale);
+            } else {
+                maxPSI = Math.ceil(properties.getValue("max_kpa").asInteger() * 0.145033 * internal_inv_scale);
+            }
             numSlots = Math.ceil(firebox.getValue("slots").asInteger() * internal_inv_scale);
             width = Math.ceil(firebox.getValue("width").asInteger() * internal_inv_scale);
             tender_auto_feed = properties.getValue("tender_auto_feed").asBoolean(true);

--- a/src/main/resources/assets/immersiverailroading/lang/en_us.lang
+++ b/src/main/resources/assets/immersiverailroading/lang/en_us.lang
@@ -117,6 +117,7 @@ gui.immersiverailroading:track.place_blueprint_false=Place:      Track
 
 gui.immersiverailroading:loco.works=Works:          %s
 gui.immersiverailroading:loco.horse_power=Horse Power: %s
+gui.immersiverailroading:loco.power=Power:          %s
 gui.immersiverailroading:loco.tractive_effort=Traction       %s Newtons
 gui.immersiverailroading:loco.max_speed=Max Speed:    %s
 gui.immersiverailroading:stock.gauge=Gauge:          %s

--- a/src/main/resources/assets/immersiverailroading/rolling_stock/default/locomotive.caml
+++ b/src/main/resources/assets/immersiverailroading/rolling_stock/default/locomotive.caml
@@ -7,8 +7,10 @@ properties =
 
     cab_car = False             # Optional: Cab Cars don't have any motive power, but can be MU'd
     # The following are ignored if cab_car = True
-    horsepower = null           # Required
-    tractive_effort_lbf = null  # Required
+    horsepower = null              # Required
+    kilo_watt = null               # Required if horsepower not defined
+    tractive_effort_lbf = null     # Required
+    tractive_effort_newton = null  # Required if lbf not defined
     max_speed_kmh = null        # Required
     multi_unit_capable = False  # Optional: Defaults to true for Diesel Electrics
 

--- a/src/main/resources/assets/immersiverailroading/rolling_stock/default/steam.caml
+++ b/src/main/resources/assets/immersiverailroading/rolling_stock/default/steam.caml
@@ -3,7 +3,8 @@ import: "immersiverailroading:rolling_stock/default/locomotive.caml"
 properties =
     # The following is ignored if cab_car is set to True
     water_capacity_l = null   # Required: Boiler fluid capacity in liters
-    max_psi = null            # Required: Maximum boiler pressure in PSI
+    max_psi = null  # Required: Maximum boiler pressure in PSI
+    max_kpa = null  # Required if PSI not defined: Maximum boiler pressure in kPa
     firebox =                 # Firebox Properties
         slots = null              # Required: Number of slots in this container
         width = null              # Required: Width of the container, recommended to be a numeric factor of the width ex: 32 and 8


### PR DESCRIPTION
This pr 
1. Adds overrides for current locomotive difinition to support SI Units, including `max_kpa` for `max_psi`, `kilo_watt` for `horsepower`, `tractive_effort_newton` for `tractive_effort_lbf`;
2. Adds `kpa` as a unit of pressure
3. Add power unit selection for locomotive tooltip to replace fixed horsepower, including `W`, `kW` and `hp`