### PR TITLE
Remove decimals from locomotive tooltips

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/registry/LocomotiveDefinition.java
+++ b/src/main/java/cam72cam/immersiverailroading/registry/LocomotiveDefinition.java
@@ -90,13 +90,13 @@ public abstract class LocomotiveDefinition extends FreightDefinition {
         tips.add(GuiText.LOCO_WORKS.toString(this.works));
         if (!isCabCar) {
             float power = ConfigGraphics.powerUnit.convertFromWatt(this.getWatt(gauge));
-            String p = String.format("%.2f", power);
+            String p = String.format("%.0f", power);
             tips.add(GuiText.LOCO_POWER.toString(p) + ConfigGraphics.powerUnit.toUnitString());
             float force = ConfigGraphics.forceUnit.convertFromNewton(this.getStartingTractionNewtons(gauge));
-            String f = String.format("%.2f", force);
+            String f = String.format("%.0f", force);
             tips.add(GuiText.LOCO_TRACTION.toString(f) + ConfigGraphics.forceUnit.toUnitString());
             float speed = (float) ConfigGraphics.speedUnit.convertFromKmh(this.getMaxSpeed(gauge).metric());
-            String v = String.format("%.2f", speed);
+            String v = String.format("%.0f", speed);
             tips.add(GuiText.LOCO_MAX_SPEED.toString(v) + ConfigGraphics.speedUnit.toUnitString());
         }
         return tips;


### PR DESCRIPTION
Remove 2 decimal figures added to locomotive tooltips in [376a848](https://github.com/TeamOpenIndustry/ImmersiveRailroading/commit/376a8480bcab012e376c8b7b6b717b559b329dfb).
These decimals shouldn't have been added as far as I can tell and some of them are useless: e.g. power in kW gets rounded to the nearest kW when reading the stock definition file, so it will never have any decimals in the tooltip, and watt especially won't.
This is a very simple fix, simply setting the format to not display any decimals instead of 2.
This applies to power, force, and speed tags in the tooltip.