### PR TITLE
Adjusted hp, added ps, adjusted default config, organized unit library

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/ConfigGraphics.java
+++ b/src/main/java/cam72cam/immersiverailroading/ConfigGraphics.java
@@ -20,20 +20,20 @@ public class ConfigGraphics {
 	@Comment( "Self explanatory" )
 	public static boolean trainsOnTheBrain = true;
 	
-	@Comment("What unit to use for speedometer. (kmh, mph or ms)" )
+	@Comment("What unit to display speed in (kmh, ms, mph)")
 	public static SpeedDisplayType speedUnit = SpeedDisplayType.kmh;
 
-	@Comment("What unit to display pressure in (psi, bar, kpa)")
-	public static PressureDisplayType pressureUnit = PressureDisplayType.psi;
+	@Comment("What unit to display pressure in (psi, kpa, bar)")
+	public static PressureDisplayType pressureUnit = PressureDisplayType.bar;
 
-	@Comment("What unit to display pressure in (psi, bar)")
+	@Comment("What unit to display temperature in (celcius, kelvin, farenheit)")
 	public static TemperatureDisplayType temperatureUnit = TemperatureDisplayType.celcius;
 
-	@Comment("What unit to display locomotive power in (W, kW, horsepower)")
-	public static PowerDisplayType powerUnit = PowerDisplayType.w;
+	@Comment("What unit to display locomotive power in (w, kw, ps (metric horsepower), horsepower (imperial horsepower))")
+	public static PowerDisplayType powerUnit = PowerDisplayType.kw;
 
-	@Comment("What unit to display locomotive traction force in (N, kN, lbf)")
-	public static ForceDisplayType forceUnit = ForceDisplayType.n;
+	@Comment("What unit to display locomotive traction force in (kn, n, lbf)")
+	public static ForceDisplayType forceUnit = ForceDisplayType.kn;
 
 	@Comment( "How long to keep textures in memory after they have left the screen (higher numbers = smoother game play, lower numbers = less GPU memory used)")
 	@Range(min = 0, max = 100)

--- a/src/main/java/cam72cam/immersiverailroading/library/unit/ForceDisplayType.java
+++ b/src/main/java/cam72cam/immersiverailroading/library/unit/ForceDisplayType.java
@@ -1,20 +1,19 @@
 package cam72cam.immersiverailroading.library.unit;
 
 public enum ForceDisplayType {
-    n,
     kn,
-    lbf,
-    ;
+    n,
+    lbf;
 
     public static final float lbfToNewton = 4.448221f;
 
     public float convertFromNewton(float value) {
         switch (this) {
-            case n:
             default:
-                return value;
             case kn:
                 return value / 1000f;
+            case n:
+                return value;
             case lbf:
                 return value * 0.224809f;
         }
@@ -22,11 +21,11 @@ public enum ForceDisplayType {
 
     public String toUnitString() {
         switch (this) {
-            case n:
             default:
-                return "N";
             case kn:
                 return "kN";
+            case n:
+                return "N";
             case lbf:
                 return "lbf";
         }

--- a/src/main/java/cam72cam/immersiverailroading/library/unit/PowerDisplayType.java
+++ b/src/main/java/cam72cam/immersiverailroading/library/unit/PowerDisplayType.java
@@ -1,24 +1,28 @@
 package cam72cam.immersiverailroading.library.unit;
 
 public enum PowerDisplayType {
-    horsepower,
-    w,
     kw,
-    ;
+    w,
+    horsepower,
+    ps;
 
-    public static final float kwToHp = 1.359621f;
-    public static final float hpToKW = 0.735499f;
-    public static final float wToHp = 0.00135962f;
+    public static final float kWToHp = 1.34102f;
+    public static final float hpToKW = 0.745701f;
+    public static final float wToHp = 0.00134102f;
+    public static final float PSToKW = 0.735498f;
+    public static final float wToPS = 0.00135962f;
 
     public float convertFromWatt(float value) {
         switch (this) {
-            case w:
-                return value;
+            default:
             case kw:
                 return value / 1000f;
+            case w:
+                return value;
             case horsepower:
-            default:
                 return value * wToHp;
+            case ps:
+                return value * wToPS;
         }
     }
 
@@ -28,6 +32,8 @@ public enum PowerDisplayType {
                 return "W";
             case kw:
                 return "kW";
+            case ps:
+                return "PS";
             case horsepower:
             default:
                 return "hp";

--- a/src/main/java/cam72cam/immersiverailroading/library/unit/PressureDisplayType.java
+++ b/src/main/java/cam72cam/immersiverailroading/library/unit/PressureDisplayType.java
@@ -1,9 +1,9 @@
 package cam72cam.immersiverailroading.library.unit;
 
 public enum PressureDisplayType {
-    psi,
     bar,
-    kpa;
+    kpa,
+    psi;
 
     public static final float psiToKPa = 6.89474f;
     public static final float kPaToPsi = 0.145037f;
@@ -13,20 +13,24 @@ public enum PressureDisplayType {
     public float convertFromPSI(float value) {
         switch (this) {
             // 1 bar = 100 kPa
-            case bar: return value * psiToKPa * 0.01f;
-            case kpa: return value * psiToKPa;
-            default: return value;
+            default:
+            case bar:
+                return value * psiToBar;
+            case kpa:
+                return value * psiToKPa;
+            case psi:
+                return value;
         }
     }
 
     public String toUnitString() {
         switch (this) {
+            default:
             case bar:
                 return "bar";
             case kpa:
                 return "kPa";
             case psi:
-            default:
                 return "psi";
         }
     }

--- a/src/main/java/cam72cam/immersiverailroading/library/unit/SpeedDisplayType.java
+++ b/src/main/java/cam72cam/immersiverailroading/library/unit/SpeedDisplayType.java
@@ -2,8 +2,8 @@ package cam72cam.immersiverailroading.library.unit;
 
 public enum SpeedDisplayType {
 	kmh,
-	mph,
-	ms;
+	ms,
+	mph;
 
 	public double convertFromKmh(double value) {
 		switch (this) {
@@ -22,10 +22,10 @@ public enum SpeedDisplayType {
 			default:
 			case kmh:
 				return "km/h";
-			case mph:
-				return "mph";
 			case ms:
 				return "m/s";
+			case mph:
+				return "mph";
 		}
 	}
 }

--- a/src/main/java/cam72cam/immersiverailroading/library/unit/TemperatureDisplayType.java
+++ b/src/main/java/cam72cam/immersiverailroading/library/unit/TemperatureDisplayType.java
@@ -2,18 +2,18 @@ package cam72cam.immersiverailroading.library.unit;
 
 public enum TemperatureDisplayType {
     celcius,
-    farenheit,
-    kelvin,;
+    kelvin,
+    farenheit;
 
     public float convertFromCelcius(float value) {
         switch (this) {
             default:
             case celcius:
                 return value;
-            case farenheit:
-                return (value * 9f/5f) + 32f;
             case kelvin:
                 return value + 273.15f;
+            case farenheit:
+                return (value * 9f/5f) + 32f;
         }
     }
 
@@ -21,11 +21,11 @@ public enum TemperatureDisplayType {
         switch (this) {
             default:
             case celcius:
-                return "C";
-            case farenheit:
-                return "F";
+                return "°C";
             case kelvin:
                 return "K";
+            case farenheit:
+                return "°F";
         }
     }
 }

--- a/src/main/java/cam72cam/immersiverailroading/registry/LocomotiveDefinition.java
+++ b/src/main/java/cam72cam/immersiverailroading/registry/LocomotiveDefinition.java
@@ -60,6 +60,8 @@ public abstract class LocomotiveDefinition extends FreightDefinition {
                 power_kW = properties.getValue("horsepower").asFloat() * PowerDisplayType.hpToKW * internal_inv_scale;
             } else if (properties.getValue("power_hp").asFloat() != null) {
                 power_kW = properties.getValue("power_hp").asFloat() * PowerDisplayType.hpToKW * internal_inv_scale;
+            } else if (properties.getValue("power_ps").asFloat() != null) {
+                power_kW = properties.getValue("power_ps").asFloat() * PowerDisplayType.PSToKW * internal_inv_scale;
             } else if (properties.getValue("power_kw").asFloat() != null) {
                 power_kW = properties.getValue("power_kw").asFloat() * internal_inv_scale;
             } else {
@@ -99,19 +101,19 @@ public abstract class LocomotiveDefinition extends FreightDefinition {
         if (!isCabCar) {
             float power = ConfigGraphics.powerUnit.convertFromWatt(this.getWatt(gauge));
             String p = String.format("%.0f", power);
-            tips.add(GuiText.LOCO_POWER.toString(p) + ConfigGraphics.powerUnit.toUnitString());
+            tips.add(GuiText.LOCO_POWER.toString(p) + " " + ConfigGraphics.powerUnit.toUnitString());
             float force = ConfigGraphics.forceUnit.convertFromNewton(this.getStartingTractionNewtons(gauge));
             String f = String.format("%.0f", force);
-            tips.add(GuiText.LOCO_TRACTION.toString(f) + ConfigGraphics.forceUnit.toUnitString());
+            tips.add(GuiText.LOCO_TRACTION.toString(f) + " " + ConfigGraphics.forceUnit.toUnitString());
             float speed = (float) ConfigGraphics.speedUnit.convertFromKmh(this.getMaxSpeed(gauge).metric());
             String v = String.format("%.0f", speed);
-            tips.add(GuiText.LOCO_MAX_SPEED.toString(v) + ConfigGraphics.speedUnit.toUnitString());
+            tips.add(GuiText.LOCO_MAX_SPEED.toString(v) + " " + ConfigGraphics.speedUnit.toUnitString());
         }
         return tips;
     }
 
     public float getHorsePower(Gauge gauge) {
-        return (float) (gauge.scale() * this.power_kW * PowerDisplayType.kwToHp);
+        return (float) (gauge.scale() * this.power_kW * PowerDisplayType.kWToHp);
     }
 
     public float getWatt(Gauge gauge) {

--- a/src/main/resources/assets/immersiverailroading/lang/en_us.lang
+++ b/src/main/resources/assets/immersiverailroading/lang/en_us.lang
@@ -116,16 +116,15 @@ gui.immersiverailroading:track.place_blueprint_true=Place:      Blueprint
 gui.immersiverailroading:track.place_blueprint_false=Place:      Track
 
 gui.immersiverailroading:loco.works=Works:          %s
-gui.immersiverailroading:loco.horse_power=Horse Power: %s
 gui.immersiverailroading:loco.power=Power:          %s
-gui.immersiverailroading:loco.tractive_effort=Traction       %s
+gui.immersiverailroading:loco.tractive_effort=Tractive Eff:  %s
 gui.immersiverailroading:loco.max_speed=Max Speed:    %s
 gui.immersiverailroading:stock.gauge=Gauge:          %s
 gui.immersiverailroading:stock.texture=Variant:        %s
 gui.immersiverailroading:cast.raw=Requires processing in the steam hammer before use!
 gui.immersiverailroading:stock.tank_capacity=Capacity:       %s Buckets
 gui.immersiverailroading:stock.freight_capacity=Capacity:       %s Stacks
-gui.immersiverailroading:stock.weight=Weight:          %s Kg
+gui.immersiverailroading:stock.weight=Weight:          %s kg
 gui.immersiverailroading:stock.modeler=Modeler:        %s
 gui.immersiverailroading:stock.pack=Pack:            %s
 

--- a/src/main/resources/assets/immersiverailroading/rolling_stock/default/locomotive.caml
+++ b/src/main/resources/assets/immersiverailroading/rolling_stock/default/locomotive.caml
@@ -16,14 +16,16 @@ properties =
     cab_car = False                # Optional: Cab Cars don't have any motive power, but can be MU'd
 
     # The following are ignored if cab_car = True
-    power_hp = null                # Required: Any power definition
-    power_kw = null
+    power_kw = null                # Required: Any power definition
     power_w = null
+    power_ps = null                # Metric horsepower
+    power_hp = null                # Imperial horsepower
     horsepower = null              # Old format for power
 
-    tractive_effort_lbf = null     # Required: any of the tractive_effort definitions
-    tractive_effort_kn = null      #
-    tractive_effort_n = null       #
+    tractive_effort_kn = null      # Required: any tractive effort definition
+    tractive_effort_n = null
+    tractive_effort_lbf = null
 
     max_speed_kmh = null           # Required
-    multi_unit_capable = False      # Optional: Defaults to true for diesels
+    
+    multi_unit_capable = False     # Optional: Defaults to true for diesels

--- a/src/main/resources/assets/immersiverailroading/rolling_stock/default/steam.caml
+++ b/src/main/resources/assets/immersiverailroading/rolling_stock/default/steam.caml
@@ -3,10 +3,12 @@ import: "immersiverailroading:rolling_stock/default/locomotive.caml"
 properties =
     # The following is ignored if cab_car is set to True
     water_capacity_l = null   # Required: Boiler fluid capacity in liters
-    max_pressure_psi = null   # Required: Any max pressure definition
-    max_pressure_bar = null
+
+    max_pressure_bar = null   # Required: Any max pressure definition
     max_pressure_kpa = null
+    max_pressure_psi = null
     max_psi = null            # Old format for max pressure
+
     firebox =                 # Firebox Properties
         slots = null          # Required: Number of slots in this container
         width = null          # Required: Width of the container, recommended to be a numeric factor of the width ex: 32 and 8


### PR DESCRIPTION
Added new unit: PS (metric horsepower)
Adjusted hp to W conversion factor from metric (735.5 W) to imperial (745.7 W).
Updated and reorganized locomotive.caml and steam.caml files to improve legibility and order.
Adjusted tooltips with correctly capitalized kg and Tractive Eff. instead of Traction, as well as adding spaces between numerators and units for power, tractive effort, and speed.
Reordered and adjusted defaults for units in config so metric is the default for all of them (km/h, kW, kN, bar, °C) and they're all ordered metric, SI, imperial (except power, where PS is last, which puts it between imperial horsepower and metric in a way).
Adjusted some comments in the config to be more clear or accurate.

(The commit name includes bar because I misremembered that it was actually added in the previous PR)

I apologize for not splitting this into multiple commits, but everything was really intertwined.