### PR TITLE
[Refactor] Add MathUtil.clamp() to simplify clamp operation

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/entity/EntityMoveableRollingStock.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/EntityMoveableRollingStock.java
@@ -12,6 +12,7 @@ import cam72cam.immersiverailroading.model.part.Control;
 import cam72cam.immersiverailroading.net.SoundPacket;
 import cam72cam.immersiverailroading.physics.TickPos;
 import cam72cam.immersiverailroading.tile.TileRailBase;
+import cam72cam.immersiverailroading.util.MathUtil;
 import cam72cam.immersiverailroading.util.RealBB;
 import cam72cam.immersiverailroading.util.Speed;
 import cam72cam.mod.entity.Entity;
@@ -229,7 +230,7 @@ public abstract class EntityMoveableRollingStock extends EntityRidableRollingSto
             if (getDefinition().hasIndependentBrake()) {
                 for (Control<?> control : getDefinition().getModel().getControls()) {
                     if (!getDefinition().isLinearBrakeControl() && control.part.type == ModelComponentType.INDEPENDENT_BRAKE_X) {
-                        setIndependentBrake(Math.max(0, Math.min(1, getIndependentBrake() + (getControlPosition(control) - 0.5f) / 8)));
+                        setIndependentBrake(MathUtil.clamp(getIndependentBrake() + (getControlPosition(control) - 0.5f) / 8, 0, 1));
                     }
                 }
             }
@@ -446,7 +447,7 @@ public abstract class EntityMoveableRollingStock extends EntityRidableRollingSto
         return getDefinition().hasIndependentBrake() ? independentBrake : 0;
     }
     public void setIndependentBrake(float newIndependentBrake) {
-        newIndependentBrake = Math.min(1, Math.max(0, newIndependentBrake));
+        newIndependentBrake = MathUtil.clamp(newIndependentBrake, 0, 1);
         if (this.getIndependentBrake() != newIndependentBrake && getDefinition().hasIndependentBrake()) {
             if (getDefinition().isLinearBrakeControl()) {
                 setControlPositions(ModelComponentType.INDEPENDENT_BRAKE_X, newIndependentBrake);

--- a/src/main/java/cam72cam/immersiverailroading/entity/EntityRollingStock.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/EntityRollingStock.java
@@ -9,6 +9,7 @@ import cam72cam.immersiverailroading.library.*;
 import cam72cam.immersiverailroading.model.part.Control;
 import cam72cam.immersiverailroading.registry.DefinitionManager;
 import cam72cam.immersiverailroading.registry.EntityRollingStockDefinition;
+import cam72cam.immersiverailroading.util.MathUtil;
 import cam72cam.mod.entity.*;
 import cam72cam.mod.entity.sync.TagSync;
 import cam72cam.mod.entity.custom.*;
@@ -326,12 +327,12 @@ public class EntityRollingStock extends CustomEntity implements ITickable, IClic
 	}
 
 	public void setControlPosition(Control<?> control, float val) {
-		val = Math.min(1, Math.max(0, val));
+		val = MathUtil.clamp(val, 0, 1);
 		controlPositions.put(control.controlGroup, Pair.of(getControlPressed(control), val));
 	}
 
 	public void setControlPosition(String control, float val) {
-		val = Math.min(1, Math.max(0, val));
+		val = MathUtil.clamp(val, 0, 1);
 		controlPositions.put(control, Pair.of(false, val));
 	}
 

--- a/src/main/java/cam72cam/immersiverailroading/entity/Locomotive.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/Locomotive.java
@@ -10,6 +10,7 @@ import cam72cam.immersiverailroading.physics.MovementTrack;
 import cam72cam.immersiverailroading.registry.LocomotiveDefinition;
 import cam72cam.immersiverailroading.thirdparty.trackapi.ITrack;
 import cam72cam.immersiverailroading.tile.TileRailBase;
+import cam72cam.immersiverailroading.util.MathUtil;
 import cam72cam.immersiverailroading.util.Speed;
 import cam72cam.mod.entity.Entity;
 import cam72cam.mod.entity.Player;
@@ -330,7 +331,7 @@ public abstract class Locomotive extends FreightTank {
 			for (Control<?> control : getDefinition().getModel().getControls()) {
 				// Logic duplicated in Readouts#setValue
 				if (!getDefinition().isLinearBrakeControl() && control.part.type == ModelComponentType.TRAIN_BRAKE_X) {
-					setTrainBrake(Math.max(0, Math.min(1, getTrainBrake() + (getControlPosition(control) - 0.5f) / 8)));
+					setTrainBrake(MathUtil.clamp(getTrainBrake() + (getControlPosition(control) - 0.5f) / 8, 0, 1));
 				}
 			}
 
@@ -492,7 +493,7 @@ public abstract class Locomotive extends FreightTank {
 		}
 	}
 	private void setRealThrottle(float newThrottle) {
-		newThrottle = Math.min(1, Math.max(0, newThrottle));
+		newThrottle = MathUtil.clamp(newThrottle, 0, 1);
 		if (this.getThrottle() != newThrottle) {
 			setControlPositions(ModelComponentType.THROTTLE_X, newThrottle);
 			throttle = newThrottle;
@@ -513,7 +514,7 @@ public abstract class Locomotive extends FreightTank {
 		}
 	}
 	private void setRealReverser(float newReverser){
-		newReverser = Math.min(1, Math.max(-1, newReverser));
+		newReverser = MathUtil.clamp(newReverser, -1, 1);
 
 		if (this.getReverser() != newReverser) {
 			setControlPositions(ModelComponentType.REVERSER_X, newReverser/-2 + 0.5f);
@@ -583,7 +584,7 @@ public abstract class Locomotive extends FreightTank {
 		}
 	}
 	private void setRealTrainBrake(float newTrainBrake) {
-		newTrainBrake = Math.min(1, Math.max(0, newTrainBrake));
+		newTrainBrake = MathUtil.clamp(newTrainBrake, 0, 1);
 		if (this.getTrainBrake() != newTrainBrake) {
 			if (getDefinition().isLinearBrakeControl()) {
 				setControlPositions(ModelComponentType.TRAIN_BRAKE_X, newTrainBrake);

--- a/src/main/java/cam72cam/immersiverailroading/entity/physics/chrono/ClientChronoState.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/physics/chrono/ClientChronoState.java
@@ -1,6 +1,7 @@
 package cam72cam.immersiverailroading.entity.physics.chrono;
 
 import cam72cam.immersiverailroading.ImmersiveRailroading;
+import cam72cam.immersiverailroading.util.MathUtil;
 import cam72cam.mod.MinecraftClient;
 import cam72cam.mod.event.ClientEvents;
 import cam72cam.mod.world.World;
@@ -63,7 +64,7 @@ public class ClientChronoState implements ChronoState {
             client.tickID = server.tickID;
         } else {
             // Standard skew assumption
-            client.tickSkew += Math.max(-5, Math.min(5, delta)) / 100;
+            client.tickSkew += MathUtil.clamp(delta, -5, 5) / 100;
         }
     }
 

--- a/src/main/java/cam72cam/immersiverailroading/gui/PlateRollerGUI.java
+++ b/src/main/java/cam72cam/immersiverailroading/gui/PlateRollerGUI.java
@@ -10,6 +10,7 @@ import cam72cam.immersiverailroading.library.GuiText;
 import cam72cam.immersiverailroading.library.PlateType;
 import cam72cam.immersiverailroading.registry.EntityRollingStockDefinition;
 import cam72cam.immersiverailroading.tile.TileMultiblock;
+import cam72cam.immersiverailroading.util.MathUtil;
 import cam72cam.mod.entity.Player;
 import cam72cam.mod.gui.screen.Button;
 import cam72cam.mod.gui.screen.IScreen;
@@ -118,7 +119,7 @@ public class PlateRollerGUI implements IScreen {
 		ItemPlate.Data data = new ItemPlate.Data(currentItem);
 		data.gauge = gauge;
 		data.write();
-		currentItem.setCount(Math.min(64, Math.max(1, (int) Math.floor(data.type.platesPerBlock() / gauge.scale()))));
+		currentItem.setCount(MathUtil.clamp((int) Math.floor(data.type.platesPerBlock() / gauge.scale()), 1, 64));
 		tile.setCraftItem(currentItem);
     }
 }

--- a/src/main/java/cam72cam/immersiverailroading/gui/TrackGui.java
+++ b/src/main/java/cam72cam/immersiverailroading/gui/TrackGui.java
@@ -13,6 +13,7 @@ import cam72cam.immersiverailroading.track.BuilderTransferTable;
 import cam72cam.immersiverailroading.track.BuilderTurnTable;
 import cam72cam.immersiverailroading.track.TrackBase;
 import cam72cam.immersiverailroading.util.IRFuzzy;
+import cam72cam.immersiverailroading.util.MathUtil;
 import cam72cam.immersiverailroading.util.PlacementInfo;
 import cam72cam.immersiverailroading.util.RailInfo;
 import cam72cam.mod.MinecraftClient;
@@ -477,7 +478,7 @@ public class TrackGui implements IScreen {
 						length = 5;
 					}
 					if (settings.type == TrackItems.TURNTABLE) {
-						length = Math.min(25, Math.max(10, length));
+						length = MathUtil.clamp(length, 10, 25);
 					}
 					b.length = length;
 				}),

--- a/src/main/java/cam72cam/immersiverailroading/gui/overlay/GuiBuilder.java
+++ b/src/main/java/cam72cam/immersiverailroading/gui/overlay/GuiBuilder.java
@@ -7,6 +7,7 @@ import cam72cam.immersiverailroading.entity.LocomotiveDiesel;
 import cam72cam.immersiverailroading.library.GuiText;
 import cam72cam.immersiverailroading.registry.EntityRollingStockDefinition;
 import cam72cam.immersiverailroading.util.DataBlock;
+import cam72cam.immersiverailroading.util.MathUtil;
 import cam72cam.immersiverailroading.util.MergedBlocks;
 import cam72cam.mod.MinecraftClient;
 import cam72cam.mod.config.ConfigFile;
@@ -376,7 +377,7 @@ public class GuiBuilder {
                         && Character.isDigit(out.charAt(decimalIndex + 1))) {
                         // [stat].[digit(0~5)]
                         int dig = Character.getNumericValue(out.charAt(decimalIndex + 1));
-                        dig = Math.min(5, Math.max(0, dig));
+                        dig = MathUtil.clamp(dig, 0, 5);
 
                         out = out.replace(out.substring(index, decimalIndex + 2), stat.getValue(stock, dig));
                     } else {

--- a/src/main/java/cam72cam/immersiverailroading/gui/overlay/Readouts.java
+++ b/src/main/java/cam72cam/immersiverailroading/gui/overlay/Readouts.java
@@ -4,6 +4,7 @@ import cam72cam.immersiverailroading.entity.*;
 import cam72cam.immersiverailroading.entity.EntityCoupleableRollingStock.CouplerType;
 import cam72cam.immersiverailroading.model.LocomotiveModel;
 import cam72cam.immersiverailroading.model.StockModel;
+import cam72cam.immersiverailroading.util.MathUtil;
 
 public enum Readouts {
     LIQUID,
@@ -146,7 +147,7 @@ public enum Readouts {
                 } else {
                     if (stock instanceof Locomotive) {
                         // Logic duplicated in Locomotive#onTick
-                        ((Locomotive) stock).setTrainBrake(Math.max(0, Math.min(1, ((Locomotive) stock).getTrainBrake() + (value - 0.5f) / 80)));
+                        ((Locomotive) stock).setTrainBrake(MathUtil.clamp(((Locomotive) stock).getTrainBrake() + (value - 0.5f) / 80, 0, 1));
                     }
                 }
                 break;

--- a/src/main/java/cam72cam/immersiverailroading/model/DieselLocomotiveModel.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/DieselLocomotiveModel.java
@@ -8,6 +8,7 @@ import cam72cam.immersiverailroading.model.components.ComponentProvider;
 import cam72cam.immersiverailroading.model.components.ModelComponent;
 import cam72cam.immersiverailroading.model.part.*;
 import cam72cam.immersiverailroading.registry.LocomotiveDieselDefinition;
+import cam72cam.immersiverailroading.util.MathUtil;
 
 import java.util.HashMap;
 import java.util.List;
@@ -86,7 +87,7 @@ public class DieselLocomotiveModel extends LocomotiveModel<LocomotiveDiesel, Loc
                     boolean isThrottledUp = stock.getRelativeRPM() > 0.01;
                     float fade = runningFade.getOrDefault(stock.getUUID(), 0f);
                     fade += 0.05f * (isThrottledUp ? 1 : -1);
-                    fade = Math.min(Math.max(fade, 0), 1);
+                    fade = MathUtil.clamp(fade, 0, 1);
                     runningFade.put(stock.getUUID(), fade);
 
                     idle.effects(stock, 1 - fade + 0.01f, 1);

--- a/src/main/java/cam72cam/immersiverailroading/model/animation/StockAnimation.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/animation/StockAnimation.java
@@ -7,6 +7,7 @@ import cam72cam.immersiverailroading.model.part.PartSound;
 import cam72cam.immersiverailroading.registry.EntityRollingStockDefinition.AnimationDefinition;
 import cam72cam.immersiverailroading.registry.EntityRollingStockDefinition.AnimationDefinition.AnimationMode;
 import cam72cam.immersiverailroading.render.ExpireableMap;
+import cam72cam.immersiverailroading.util.MathUtil;
 import util.Matrix4;
 
 import java.io.IOException;
@@ -44,7 +45,7 @@ public class StockAnimation {
 
     public float getValue(EntityRollingStock stock) {
         float value = def.control_group != null ? stock.getControlPosition(def.control_group) : def.readout.getValue(stock);
-        value = Math.min(1, Math.max(0, (value - def.rangeMin) / (def.rangeMax - def.rangeMin)));
+        value = MathUtil.clamp((value - def.rangeMin) / (def.rangeMax - def.rangeMin), 0, 1);
         value += def.offset;
         return def.invert ? 1 - value : value;
     }

--- a/src/main/java/cam72cam/immersiverailroading/model/part/DieselExhaust.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/DieselExhaust.java
@@ -7,6 +7,7 @@ import cam72cam.immersiverailroading.library.Particles;
 import cam72cam.immersiverailroading.model.components.ComponentProvider;
 import cam72cam.immersiverailroading.model.components.ModelComponent;
 import cam72cam.immersiverailroading.render.SmokeParticle;
+import cam72cam.immersiverailroading.util.MathUtil;
 import cam72cam.immersiverailroading.util.VecUtil;
 import cam72cam.mod.math.Vec3d;
 
@@ -31,7 +32,7 @@ public class DieselExhaust {
                 for (ModelComponent exhaust : components) {
                     Vec3d particlePos = stock.getPosition().add(VecUtil.rotateWrongYaw(exhaust.center.scale(stock.gauge.scale()), stock.getRotationYaw() + 180));
 
-                    double smokeMod = (1 + Math.min(1, Math.max(0.2, Math.abs(stock.getCurrentSpeed().minecraft())*2)))/2;
+                    double smokeMod = (1 + MathUtil.clamp(Math.abs(stock.getCurrentSpeed().minecraft())*2, 0.2, 1))/2;
                     Particles.SMOKE.accept(new SmokeParticle.SmokeParticleData(stock.getWorld(), particlePos, new Vec3d(fakeMotion.x, fakeMotion.y + 0.4 * stock.gauge.scale(), fakeMotion.z), (int) (40 * (1+throttle) * smokeMod), throttle, throttle, exhaust.width() * stock.gauge.scale(), stock.getDefinition().smokeParticleTexture));
                 }
             }

--- a/src/main/java/cam72cam/immersiverailroading/model/part/LightFlare.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/LightFlare.java
@@ -10,6 +10,7 @@ import cam72cam.immersiverailroading.model.components.ComponentProvider;
 import cam72cam.immersiverailroading.model.components.ModelComponent;
 import cam72cam.immersiverailroading.registry.EntityRollingStockDefinition;
 import cam72cam.immersiverailroading.registry.EntityRollingStockDefinition.LightDefinition;
+import cam72cam.immersiverailroading.util.MathUtil;
 import cam72cam.immersiverailroading.util.VecUtil;
 import cam72cam.mod.MinecraftClient;
 import cam72cam.mod.math.Rotation;
@@ -178,7 +179,7 @@ public class LightFlare<T extends EntityMoveableRollingStock> {
                 subtract(flareOffset).scale(forward ? 1 : -1);
 
         int viewAngle = 45;
-        float intensity = 1 - Math.abs(Math.max(-viewAngle, Math.min(viewAngle, VecUtil.toWrongYaw(playerOffset) - 90))) / viewAngle;
+        float intensity = 1 - Math.abs(MathUtil.clamp(VecUtil.toWrongYaw(playerOffset) - 90, -viewAngle, viewAngle)) / viewAngle;
         intensity *= Math.abs(playerOffset.x/(50 * stock.gauge.scale()));
         intensity = Math.min(intensity, 1.5f);
 

--- a/src/main/java/cam72cam/immersiverailroading/model/part/Readout.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/Readout.java
@@ -8,6 +8,7 @@ import cam72cam.immersiverailroading.model.ModelState;
 import cam72cam.immersiverailroading.model.components.ComponentProvider;
 import cam72cam.immersiverailroading.model.components.ModelComponent;
 import cam72cam.immersiverailroading.util.DataBlock;
+import cam72cam.immersiverailroading.util.MathUtil;
 
 import java.util.HashMap;
 import java.util.List;
@@ -59,7 +60,7 @@ public class Readout<T extends EntityMoveableRollingStock> extends Control<T> {
     @Override
     public float getValue(EntityMoveableRollingStock stock) {
         float pos = positions.getOrDefault(stock.getUUID(), 0f);
-        pos = Math.min(1, Math.max(0, (pos - rangeMin) / (rangeMax - rangeMin)));
+        pos = MathUtil.clamp((pos - rangeMin) / (rangeMax - rangeMin), 0, 1);
         pos = pos + offset;
         return invert ? 1 - pos : pos;
     }

--- a/src/main/java/cam72cam/immersiverailroading/model/part/SteamChimney.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/SteamChimney.java
@@ -8,6 +8,7 @@ import cam72cam.immersiverailroading.library.Particles;
 import cam72cam.immersiverailroading.model.components.ComponentProvider;
 import cam72cam.immersiverailroading.model.components.ModelComponent;
 import cam72cam.immersiverailroading.render.SmokeParticle;
+import cam72cam.immersiverailroading.util.MathUtil;
 import cam72cam.immersiverailroading.util.VecUtil;
 import cam72cam.mod.math.Vec3d;
 import cam72cam.mod.resource.Identifier;
@@ -39,12 +40,12 @@ public class SteamChimney {
             if (darken == 0 && Config.isFuelRequired(stock.gauge)) {
                 return;
             }
-            darken /= stock.getInventorySize() - 2.0;
-            darken *= 0.75;
+            darken /= (stock.getInventorySize() - 2.0f);
+            darken *= 0.75f;
             for (ModelComponent smoke : emitter) {
                 Vec3d particlePos = stock.getPosition().add(VecUtil.rotateWrongYaw(smoke.center.scale(stock.gauge.scale()), stock.getRotationYaw() + 180));
 
-                double smokeMod = Math.min(1, Math.max(0.2, Math.abs(stock.getCurrentSpeed().minecraft())*2));
+                double smokeMod = MathUtil.clamp(Math.abs(stock.getCurrentSpeed().minecraft())*2, 0.2, 1);
 
                 int lifespan = (int) (200 * (1 + exhaust) * smokeMod * stock.gauge.scale());
 

--- a/src/main/java/cam72cam/immersiverailroading/model/part/Whistle.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/Whistle.java
@@ -11,6 +11,7 @@ import cam72cam.immersiverailroading.registry.EntityRollingStockDefinition;
 import cam72cam.immersiverailroading.registry.Quilling;
 import cam72cam.immersiverailroading.render.ExpireableMap;
 import cam72cam.immersiverailroading.render.SmokeParticle;
+import cam72cam.immersiverailroading.util.MathUtil;
 import cam72cam.immersiverailroading.util.VecUtil;
 import cam72cam.mod.math.Vec3d;
 import cam72cam.mod.sound.ISound;
@@ -64,21 +65,21 @@ public class Whistle {
                         soundDampener = 0.4f;
                     }
                     if (soundDampener < 1) {
-                        soundDampener += 0.1;
+                        soundDampener += 0.1f;
                     }
                     delta = hornPull - pullString;
                 } else {
                     if (soundDampener > 0) {
-                        soundDampener -= 0.07;
+                        soundDampener -= 0.07f;
                     }
                     // Player probably released key or has net lag
                     delta = -pullString;
                 }
 
                 if (pullString == 0) {
-                    pullString += delta * 0.55;
+                    pullString += delta * 0.55f;
                 } else {
-                    pullString += Math.max(Math.min(delta, maxDelta), -maxDelta);
+                    pullString += MathUtil.clamp(delta, -maxDelta, maxDelta);
                 }
                 pullString = Math.min(pullString, (float) quilling.maxPull);
 
@@ -147,7 +148,7 @@ public class Whistle {
 
             float darken = 0;
             float thickness = 1;
-            double smokeMod = Math.min(1, Math.max(0.2, Math.abs(stock.getCurrentSpeed().minecraft()) * 2));
+            double smokeMod = MathUtil.clamp(Math.abs(stock.getCurrentSpeed().minecraft()) * 2, 0.2, 1);
             int lifespan = (int) (40 * (1 + smokeMod * stock.gauge.scale()));
             double verticalSpeed = 0.8f * stock.gauge.scale();
             double size = 0.3 * (0.8 + smokeMod) * stock.gauge.scale();

--- a/src/main/java/cam72cam/immersiverailroading/registry/DefinitionManager.java
+++ b/src/main/java/cam72cam/immersiverailroading/registry/DefinitionManager.java
@@ -7,6 +7,7 @@ import cam72cam.immersiverailroading.util.DataBlock;
 import cam72cam.immersiverailroading.library.Gauge;
 import cam72cam.immersiverailroading.model.TrackModel;
 import cam72cam.immersiverailroading.util.JSON;
+import cam72cam.immersiverailroading.util.MathUtil;
 import cam72cam.mod.gui.Progress;
 import cam72cam.mod.resource.Identifier;
 import org.apache.commons.lang3.tuple.Pair;
@@ -131,7 +132,8 @@ public class DefinitionManager {
             ImmersiveRailroading.catching(ex);
         }
 
-        int loadingThreads = Math.max(1, Math.min(processors, (int) (maxMemory / (ConfigPerformance.megabytesReservedPerStockLoadingThread * 1024L * 1024L))));
+        long bytesPerThread = ConfigPerformance.megabytesReservedPerStockLoadingThread * 1024L * 1024L;
+        int loadingThreads = MathUtil.clamp((int) (maxMemory / bytesPerThread), 1, processors);
         ImmersiveRailroading.info("Using %s threads to load Immersive Railroading (%sMB per thread)", loadingThreads, ConfigPerformance.megabytesReservedPerStockLoadingThread);
         ForkJoinPool stockLoadingPool = new ForkJoinPool(loadingThreads, pool -> {
             final ForkJoinWorkerThread worker = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool);

--- a/src/main/java/cam72cam/immersiverailroading/tile/TileRail.java
+++ b/src/main/java/cam72cam/immersiverailroading/tile/TileRail.java
@@ -100,7 +100,7 @@ public class TileRail extends TileRailBase {
 
 		Vec3i offset = pos.subtract(parent.getPos().subtract(mainOffset)).rotate(Rotation.from(parent.info.placementInfo.facing().getOpposite()));
 
-		this.tableIndex = Math.max(0, Math.min(info.settings.transfertableEntryCount - 1, Math.round(Math.abs((float) offset.x) / this.info.settings.transfertableEntrySpacing)));
+		this.tableIndex = MathUtil.clamp(Math.round(Math.abs((float) offset.x) / this.info.settings.transfertableEntrySpacing), 0, info.settings.transfertableEntryCount - 1);
 	}
 
 	@Override

--- a/src/main/java/cam72cam/immersiverailroading/util/MathUtil.java
+++ b/src/main/java/cam72cam/immersiverailroading/util/MathUtil.java
@@ -44,4 +44,21 @@ public class MathUtil {
 		}
 		return gcd(b, a % b);
 	}
+
+	//Enough for now
+	public static int clamp(int val, int min, int max) {
+		return Math.max(min, Math.min(max, val));
+	}
+
+	public static long clamp(long val, long min, long max) {
+		return Math.max(min, Math.min(max, val));
+	}
+
+	public static float clamp(float val, float min, float max) {
+		return Math.max(min, Math.min(max, val));
+	}
+
+	public static double clamp(double val, double min, double max) {
+		return Math.max(min, Math.min(max, val));
+	}
 }

--- a/src/main/java/cam72cam/immersiverailroading/util/PlacementInfo.java
+++ b/src/main/java/cam72cam/immersiverailroading/util/PlacementInfo.java
@@ -26,7 +26,7 @@ public class PlacementInfo {
 	}
 
 	public static int segmentation() {
-		return Math.min(90, Math.max(1, Config.ConfigBalance.AnglePlacementSegmentation));
+		return MathUtil.clamp(Config.ConfigBalance.AnglePlacementSegmentation, 1, 90);
 	}
 	
 	public PlacementInfo(ItemStack stack, float yawHead, Vec3d hit) {

--- a/src/main/java/cam72cam/immersiverailroading/util/RealBB.java
+++ b/src/main/java/cam72cam/immersiverailroading/util/RealBB.java
@@ -166,7 +166,7 @@ public class RealBB implements IBoundingBox {
 		double hack = 0.05;
 		Double intersect = intersectsAt(other.min().subtract(hack, 0, hack), other.max().add(hack, 0, hack), true).getRight();
 		double minY = other.min().y;
-		return Math.max(-0.1, Math.min(0.1, intersect - minY));
+		return MathUtil.clamp(intersect - minY, -0.1, 0.1);
 	}
 	@Override
 	public double calculateZOffset(IBoundingBox other, double offsetZ) {
@@ -214,17 +214,16 @@ public class RealBB implements IBoundingBox {
 			actualYMax = this.centerY;
 
 			Rectangle2D bds = otherShape.getBounds2D();
-			
 
 			double px = bds.getMinX() - (this.centerX - length/2);
-			double pz =bds.getMinY() - (this.centerZ - width/2);
+			double pz = bds.getMinY() - (this.centerZ - width/2);
 			double Px = bds.getMaxX() - (this.centerX - length/2);
-			double Pz =bds.getMaxY() - (this.centerZ - width/2);
-			
-			double cx = Math.max(0, Math.min(length, px));
-			double cz = Math.max(0, Math.min(width, pz));
-			double Cx = Math.max(0, Math.min(length, Px));
-			double Cz = Math.max(0, Math.min(width, Pz));
+			double Pz = bds.getMaxY() - (this.centerZ - width/2);
+
+			double cx = MathUtil.clamp(px, 0, length);
+			double cz = MathUtil.clamp(pz, 0, width);
+			double Cx = MathUtil.clamp(Px, 0, length);
+			double Cz = MathUtil.clamp(Pz, 0, width);
 
 			cx = (cx/length*xRes);
 			cz = (cz/width*zRes);


### PR DESCRIPTION
This PR adds `MathUtil.clamp()` method (`int`, `long`, `float`, `double`) to replace old `Math.min(max, Math.max(min, val))` call