### PR TITLE
[Feature] Re: Ability to define multple particle textures

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/ImmersiveRailroading.java
+++ b/src/main/java/cam72cam/immersiverailroading/ImmersiveRailroading.java
@@ -41,11 +41,13 @@ import cam72cam.mod.resource.Identifier;
 import cam72cam.mod.sound.Audio;
 import cam72cam.mod.text.Command;
 
+import java.util.Random;
 import java.util.function.Function;
 
 public class ImmersiveRailroading extends ModCore.Mod {
     public static final String MODID = "immersiverailroading";
 
+	public static final Random RANDOM = new Random();
 	public static final int ENTITY_SYNC_DISTANCE = 512;
 	private static ImmersiveRailroading instance;
 

--- a/src/main/java/cam72cam/immersiverailroading/model/part/DieselExhaust.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/DieselExhaust.java
@@ -8,10 +8,11 @@ import cam72cam.immersiverailroading.model.components.ComponentProvider;
 import cam72cam.immersiverailroading.model.components.ModelComponent;
 import cam72cam.immersiverailroading.render.SmokeParticle;
 import cam72cam.immersiverailroading.util.MathUtil;
-import cam72cam.immersiverailroading.util.VecUtil;
 import cam72cam.mod.math.Vec3d;
+import cam72cam.mod.resource.Identifier;
 
 import java.util.List;
+import java.util.Random;
 
 public class DieselExhaust {
     private final List<ModelComponent> components;
@@ -31,8 +32,9 @@ public class DieselExhaust {
                 Vec3d fakeMotion = stock.getVelocity();
                 for (ModelComponent exhaust : components) {
                     Vec3d particlePos = stock.getModelMatrix().apply(exhaust.center);
-                    double smokeMod = (1 + MathUtil.clamp(Math.abs(stock.getCurrentSpeed().minecraft())*2, 0.2, 1))/2;
-                    Particles.SMOKE.accept(new SmokeParticle.SmokeParticleData(stock.getWorld(), particlePos, new Vec3d(fakeMotion.x, fakeMotion.y + 0.4 * stock.gauge.scale(), fakeMotion.z), (int) (40 * (1+throttle) * smokeMod), throttle, throttle, exhaust.width() * stock.gauge.scale(), stock.getDefinition().smokeParticleTexture));
+                    double smokeMod = (1 + Math.clamp(Math.abs(stock.getCurrentSpeed().minecraft())*2, 0.2, 1)) / 2;
+                    Particles.SMOKE.accept(new SmokeParticle.SmokeParticleData(stock.getWorld(), particlePos, new Vec3d(fakeMotion.x, fakeMotion.y + 0.4 * stock.gauge.scale(), fakeMotion.z),
+                                                                               (int) (40 * (1+throttle) * smokeMod), throttle, throttle, exhaust.width() * stock.gauge.scale(), stock.getDefinition().getSmokeParticle()));
                 }
             }
         }

--- a/src/main/java/cam72cam/immersiverailroading/model/part/DieselExhaust.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/DieselExhaust.java
@@ -7,12 +7,9 @@ import cam72cam.immersiverailroading.library.Particles;
 import cam72cam.immersiverailroading.model.components.ComponentProvider;
 import cam72cam.immersiverailroading.model.components.ModelComponent;
 import cam72cam.immersiverailroading.render.SmokeParticle;
-import cam72cam.immersiverailroading.util.MathUtil;
 import cam72cam.mod.math.Vec3d;
-import cam72cam.mod.resource.Identifier;
 
 import java.util.List;
-import java.util.Random;
 
 public class DieselExhaust {
     private final List<ModelComponent> components;

--- a/src/main/java/cam72cam/immersiverailroading/model/part/PressureValve.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/PressureValve.java
@@ -56,7 +56,7 @@ public class PressureValve {
             Vec3d fakeMotion = stock.getVelocity();
             for (ModelComponent valve : valves) {
                 Vec3d particlePos = stock.getPosition().add(VecUtil.rotateWrongYaw(valve.center.scale(stock.gauge.scale()), stock.getRotationYaw() + 180));
-                Particles.SMOKE.accept(new SmokeParticle.SmokeParticleData(stock.getWorld(), particlePos, new Vec3d(fakeMotion.x, fakeMotion.y + 0.2 * stock.gauge.scale(), fakeMotion.z),40, 0, 0.2f, valve.width() * stock.gauge.scale(), stock.getDefinition().steamParticleTexture));
+                Particles.SMOKE.accept(new SmokeParticle.SmokeParticleData(stock.getWorld(), particlePos, new Vec3d(fakeMotion.x, fakeMotion.y + 0.2 * stock.gauge.scale(), fakeMotion.z),40, 0, 0.2f, valve.width() * stock.gauge.scale(), stock.getDefinition().getSteamParticle()));
             }
         }
     }

--- a/src/main/java/cam72cam/immersiverailroading/model/part/SteamChimney.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/SteamChimney.java
@@ -58,7 +58,7 @@ public class SteamChimney {
                     verticalSpeed *= phaseSpike;
                 }
                 isSmokeParticle = !isSmokeParticle;
-                Identifier particleTex = isSmokeParticle ? stock.getDefinition().smokeParticleTexture : stock.getDefinition().steamParticleTexture;
+                Identifier particleTex = isSmokeParticle ? stock.getDefinition().getSmokeParticle() : stock.getDefinition().getSteamParticle();
                 Particles.SMOKE.accept(new SmokeParticle.SmokeParticleData(stock.getWorld(), particlePos, new Vec3d(fakeMotion.x, fakeMotion.y + verticalSpeed, fakeMotion.z), lifespan , darken, thickness, size, particleTex));
             }
         }

--- a/src/main/java/cam72cam/immersiverailroading/model/part/ValveGear.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/ValveGear.java
@@ -158,7 +158,7 @@ public abstract class ValveGear {
                 particlePos = particlePos(stock);
                 double accell = 0.3 * stock.gauge.scale();
                 Vec3d sideMotion = stock.getVelocity().add(VecUtil.rotateWrongYaw(particlePos.getLeft().apply(direction).scale(accell), stock.getRotationYaw()+180));
-                Particles.SMOKE.accept(new SmokeParticle.SmokeParticleData(stock.getWorld(), particlePos.getRight(), new Vec3d(sideMotion.x, sideMotion.y+0.01 * stock.gauge.scale(), sideMotion.z), 80, 0, 0.6f, 0.2 * stock.gauge.scale(), stock.getDefinition().steamParticleTexture));
+                Particles.SMOKE.accept(new SmokeParticle.SmokeParticleData(stock.getWorld(), particlePos.getRight(), new Vec3d(sideMotion.x, sideMotion.y+0.01 * stock.gauge.scale(), sideMotion.z), 80, 0, 0.6f, 0.2 * stock.gauge.scale(), stock.getDefinition().getSteamParticle()));
             }
 
             if (stock instanceof LocomotiveSteam) {

--- a/src/main/java/cam72cam/immersiverailroading/model/part/Whistle.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/part/Whistle.java
@@ -153,7 +153,7 @@ public class Whistle {
             double verticalSpeed = 0.8f * stock.gauge.scale();
             double size = 0.3 * (0.8 + smokeMod) * stock.gauge.scale();
 
-            Particles.SMOKE.accept(new SmokeParticle.SmokeParticleData(stock.getWorld(), particlePos, new Vec3d(fakeMotion.x, fakeMotion.y + verticalSpeed, fakeMotion.z), lifespan, darken, thickness, size, stock.getDefinition().steamParticleTexture));
+            Particles.SMOKE.accept(new SmokeParticle.SmokeParticleData(stock.getWorld(), particlePos, new Vec3d(fakeMotion.x, fakeMotion.y + verticalSpeed, fakeMotion.z), lifespan, darken, thickness, size, stock.getDefinition().getSteamParticle()));
         }
     }
 

--- a/src/main/java/cam72cam/immersiverailroading/registry/EntityRollingStockDefinition.java
+++ b/src/main/java/cam72cam/immersiverailroading/registry/EntityRollingStockDefinition.java
@@ -92,8 +92,8 @@ public abstract class EntityRollingStockDefinition {
     private final Function<EntityBuildableRollingStock, float[][]> heightmap;
     private final Map<String, LightDefinition> lights = new HashMap<>();
     protected final Map<String, ControlSoundsDefinition> controlSounds = new HashMap<>();
-    public Identifier smokeParticleTexture;
-    public Identifier steamParticleTexture;
+    private List<Identifier> smokeParticleTextures;
+    private List<Identifier> steamParticleTextures;
     private boolean isLinearBrakeControl;
     private GuiBuilder overlay;
     private List<String> extraTooltipInfo;
@@ -535,16 +535,29 @@ public abstract class EntityRollingStockDefinition {
             extra_tooltip_info.forEach(value -> extraTooltipInfo.add(value.asString()));
         }
 
-        smokeParticleTexture = steamParticleTexture = DEFAULT_PARTICLE_TEXTURE;
+        smokeParticleTextures = steamParticleTextures = List.of(DEFAULT_PARTICLE_TEXTURE);
         DataBlock particles = data.getBlock("particles");
         if (particles != null) {
             DataBlock smoke = particles.getBlock("smoke");
             if (smoke != null) {
-                smokeParticleTexture = new Identifier(smoke.getValue("texture").asString());
+                List<DataBlock.Value> smokeTextures = smoke.getValues("texture");
+                if (smokeTextures != null) {
+                    smokeParticleTextures = smokeTextures.stream().map(val -> new Identifier(val.asString())).toList();
+                } else {
+                    //Legacy
+                    smokeParticleTextures = List.of(new Identifier(smoke.getValue("texture").asString()));
+                }
             }
+
             DataBlock steam = particles.getBlock("steam");
             if (steam != null) {
-                steamParticleTexture = new Identifier(steam.getValue("texture").asString());
+                List<DataBlock.Value> steamTextures = steam.getValues("texture");
+                if (steamTextures != null) {
+                    steamParticleTextures = steamTextures.stream().map(val -> new Identifier(val.asString())).toList();
+                } else {
+                    //Legacy
+                    steamParticleTextures = List.of(new Identifier(steam.getValue("texture").asString()));
+                }
             }
         }
 
@@ -905,6 +918,24 @@ public abstract class EntityRollingStockDefinition {
 
     public List<String> getExtraTooltipInfo() {
         return extraTooltipInfo;
+    }
+
+    public Identifier getSmokeParticle() {
+        if (smokeParticleTextures.size() == 1) {
+            //Fast fallback
+            return smokeParticleTextures.getFirst();
+        }
+        int i = ImmersiveRailroading.RANDOM.nextInt(smokeParticleTextures.size());
+        return smokeParticleTextures.get(i);
+    }
+
+    public Identifier getSteamParticle() {
+        if (steamParticleTextures.size() == 1) {
+            //Fast fallback
+            return steamParticleTextures.getFirst();
+        }
+        int i = ImmersiveRailroading.RANDOM.nextInt(steamParticleTextures.size());
+        return steamParticleTextures.get(i);
     }
 
     public double getSwayMultiplier() {

--- a/src/main/java/cam72cam/immersiverailroading/registry/EntityRollingStockDefinition.java
+++ b/src/main/java/cam72cam/immersiverailroading/registry/EntityRollingStockDefinition.java
@@ -543,6 +543,9 @@ public abstract class EntityRollingStockDefinition {
                 List<DataBlock.Value> smokeTextures = smoke.getValues("texture");
                 if (smokeTextures != null) {
                     smokeParticleTextures = smokeTextures.stream().map(val -> new Identifier(val.asString())).toList();
+                    if (smokeParticleTextures.isEmpty()) {
+                        throw new RuntimeException("Please add at least 1 particle texture in smoke textures!");
+                    }
                 } else {
                     //Legacy
                     smokeParticleTextures = List.of(new Identifier(smoke.getValue("texture").asString()));
@@ -554,6 +557,9 @@ public abstract class EntityRollingStockDefinition {
                 List<DataBlock.Value> steamTextures = steam.getValues("texture");
                 if (steamTextures != null) {
                     steamParticleTextures = steamTextures.stream().map(val -> new Identifier(val.asString())).toList();
+                    if (steamParticleTextures.isEmpty()) {
+                        throw new RuntimeException("Please add at least 1 particle texture in steam textures!");
+                    }
                 } else {
                     //Legacy
                     steamParticleTextures = List.of(new Identifier(steam.getValue("texture").asString()));

--- a/src/main/resources/assets/immersiverailroading/rolling_stock/default/base.caml
+++ b/src/main/resources/assets/immersiverailroading/rolling_stock/default/base.caml
@@ -108,8 +108,16 @@ overlay = null  # Optional: Custom in-game overlay GUI.  See examples in immersi
 particles = # Optional: Configure general particle emitter settings
     smoke =
         texture = "immersiverailroading:textures/light.png"
+        # You can set multiple textures here in another format, and IR would use them randomly
+        # In CAML, specify multiple times for multiple potential textures, like
+        # texture : "location of tex1"
+        # texture : "location of tex2"
+        # texture : "location of tex3"
+        # In JSON, like
+        # "texture" : ["location of tex1", "location of tex2", "location of tex3"]
     steam =
         texture = "immersiverailroading:textures/light.png"
+        # Similarly, steam can also use multiple textures like smoke
 
 # Each animation in CAML will have it's own animation: block
 # While in JSON it will be in the [{"properties": "values"}, {"properties": "values"}] format


### PR DESCRIPTION
A cleaned PR that is identical in core features #1674 added

This PR adds the ability to define multiple particle textures via `textures` (to avoid caml parsing conflict) and select them randomly to render

Complete document has been added to [base.caml](https://github.com/TeamOpenIndustry/ImmersiveRailroading/blob/master/src/main/resources/assets/immersiverailroading/rolling_stock/default/base.caml)